### PR TITLE
feat: implement errors module with StackPriceError and EXIT_CODES

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
   "parserOptions": {
     "ecmaVersion": 2022,
     "sourceType": "module",
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.test.json"
   },
   "plugins": ["@typescript-eslint"],
   "extends": [

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,31 @@
+// @ts-check
+const path = require('path');
+const tsParser = require('@typescript-eslint/parser');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+
+/** @type {import('eslint').Linter.Config[]} */
+module.exports = [
+  tsPlugin.configs['flat/eslint-recommended'],
+  ...tsPlugin.configs['flat/recommended'],
+  {
+    files: ['src/**/*.ts', 'tests/**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: path.resolve(__dirname, 'tsconfig.test.json'),
+        tsconfigRootDir: __dirname,
+        ecmaVersion: 2022,
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/explicit-function-return-type': 'warn',
+      '@typescript-eslint/no-unused-vars': 'error',
+      'no-console': 'off',
+    },
+  },
+];

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,16 @@
+export const EXIT_CODES = {
+  SUCCESS: 0,
+  PARTIAL: 1,
+  FAILURE: 2,
+} as const;
+
+export class StackPriceError extends Error {
+  constructor(
+    message: string,
+    public readonly exitCode: 0 | 1 | 2,
+    public readonly hint?: string,
+  ) {
+    super(message);
+    this.name = 'StackPriceError';
+  }
+}

--- a/src/errors/messages.ts
+++ b/src/errors/messages.ts
@@ -1,0 +1,30 @@
+export const NO_CREDENTIALS =
+  '✗ No AWS credentials found.\n' +
+  '  stackprice needs pricing:GetProducts to fetch pricing data.\n' +
+  '  Fix: export AWS_ACCESS_KEY_ID=... && export AWS_SECRET_ACCESS_KEY=...\n' +
+  '  Or:  aws configure\n' +
+  '  Required IAM permission: pricing:GetProducts (read-only, free to call)\n' +
+  '  Docs: github.com/suneelsristi/stackprice#credentials';
+
+export function cdkV1Detected(version: string): string {
+  return (
+    `✗ CDK v1 cloud assembly detected (schema version: ${version}).\n` +
+    '  stackprice supports CDK v2+ only.\n' +
+    '  Fix: https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html'
+  );
+}
+
+export function noManifest(dir: string): string {
+  return (
+    `✗ No CDK cloud assembly found at: ${dir}\n` +
+    `  Expected: ${dir}/manifest.json\n` +
+    '  Fix: run "cdk synth" first, then point --dir at the cdk.out directory.'
+  );
+}
+
+export function regionDefaulted(stackId: string): string {
+  return (
+    `⚠ Stack ${stackId}: region not determined. Defaulting to us-east-1.\n` +
+    '  Use --region to specify a region explicitly.'
+  );
+}

--- a/tests/unit/errors/index.test.ts
+++ b/tests/unit/errors/index.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import { EXIT_CODES, StackPriceError } from '../../../src/errors/index.js';
+import {
+  NO_CREDENTIALS,
+  cdkV1Detected,
+  noManifest,
+  regionDefaulted,
+} from '../../../src/errors/messages.js';
+
+// ─── EXIT_CODES ─────────────────────────────────────────────────────────────
+
+describe('EXIT_CODES', () => {
+  it('SUCCESS is 0', () => {
+    expect(EXIT_CODES.SUCCESS).toBe(0);
+  });
+
+  it('PARTIAL is 1', () => {
+    expect(EXIT_CODES.PARTIAL).toBe(1);
+  });
+
+  it('FAILURE is 2', () => {
+    expect(EXIT_CODES.FAILURE).toBe(2);
+  });
+});
+
+// ─── StackPriceError ─────────────────────────────────────────────────────────
+
+describe('StackPriceError', () => {
+  describe('constructor', () => {
+    it('sets message', () => {
+      const err = new StackPriceError('something went wrong', EXIT_CODES.FAILURE);
+      expect(err.message).toBe('something went wrong');
+    });
+
+    it('sets exitCode', () => {
+      const err = new StackPriceError('partial failure', EXIT_CODES.PARTIAL);
+      expect(err.exitCode).toBe(1);
+    });
+
+    it('sets name to StackPriceError', () => {
+      const err = new StackPriceError('fatal', EXIT_CODES.FAILURE);
+      expect(err.name).toBe('StackPriceError');
+    });
+
+    it('sets hint when provided', () => {
+      const err = new StackPriceError('no creds', EXIT_CODES.FAILURE, 'run aws configure');
+      expect(err.hint).toBe('run aws configure');
+    });
+
+    it('hint is undefined when not provided', () => {
+      const err = new StackPriceError('no creds', EXIT_CODES.FAILURE);
+      expect(err.hint).toBeUndefined();
+    });
+
+    it('is an instance of Error', () => {
+      const err = new StackPriceError('oops', EXIT_CODES.FAILURE);
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('is an instance of StackPriceError', () => {
+      const err = new StackPriceError('oops', EXIT_CODES.FAILURE);
+      expect(err).toBeInstanceOf(StackPriceError);
+    });
+
+    it('accepts SUCCESS exit code', () => {
+      const err = new StackPriceError('ok', EXIT_CODES.SUCCESS);
+      expect(err.exitCode).toBe(0);
+    });
+  });
+});
+
+// ─── Messages ────────────────────────────────────────────────────────────────
+
+describe('NO_CREDENTIALS', () => {
+  it('is a non-empty string', () => {
+    expect(typeof NO_CREDENTIALS).toBe('string');
+    expect(NO_CREDENTIALS.length).toBeGreaterThan(0);
+  });
+
+  it('mentions pricing:GetProducts', () => {
+    expect(NO_CREDENTIALS).toContain('pricing:GetProducts');
+  });
+
+  it('mentions aws configure', () => {
+    expect(NO_CREDENTIALS).toContain('aws configure');
+  });
+});
+
+describe('cdkV1Detected', () => {
+  it('includes the schema version in the message', () => {
+    const msg = cdkV1Detected('1.0.0');
+    expect(msg).toContain('1.0.0');
+  });
+
+  it('mentions CDK v2', () => {
+    const msg = cdkV1Detected('1.0.0');
+    expect(msg).toContain('CDK v2');
+  });
+
+  it('includes the migration docs link', () => {
+    const msg = cdkV1Detected('5.0');
+    expect(msg).toContain('https://docs.aws.amazon.com/cdk/v2/guide/migrating-v2.html');
+  });
+});
+
+describe('noManifest', () => {
+  it('includes the directory path in the message', () => {
+    const msg = noManifest('/my/cdk.out');
+    expect(msg).toContain('/my/cdk.out');
+  });
+
+  it('includes the expected manifest path', () => {
+    const msg = noManifest('/my/cdk.out');
+    expect(msg).toContain('/my/cdk.out/manifest.json');
+  });
+
+  it('mentions cdk synth', () => {
+    const msg = noManifest('/some/dir');
+    expect(msg).toContain('cdk synth');
+  });
+});
+
+describe('regionDefaulted', () => {
+  it('includes the stack ID in the message', () => {
+    const msg = regionDefaulted('MyStack');
+    expect(msg).toContain('MyStack');
+  });
+
+  it('mentions us-east-1', () => {
+    const msg = regionDefaulted('MyStack');
+    expect(msg).toContain('us-east-1');
+  });
+
+  it('mentions --region flag', () => {
+    const msg = regionDefaulted('MyStack');
+    expect(msg).toContain('--region');
+  });
+});

--- a/tests/unit/index.test.ts
+++ b/tests/unit/index.test.ts
@@ -1,7 +1,0 @@
-import { describe, it, expect } from 'vitest';
-
-describe('stackprice', () => {
-  it('placeholder — real tests coming in build phase', () => {
-    expect(true).toBe(true);
-  });
-});

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,6 @@
     "noUnusedLocals": false,
     "noUnusedParameters": false
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*", "tests/**/*"],
+  "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,5 @@ export default defineConfig({
       include: ['src/**/*.ts'],
       exclude: ['src/index.ts'],
     },
-    passWithNoTests: true,
   },
 });


### PR DESCRIPTION
- Add src/errors/index.ts: StackPriceError class and EXIT_CODES constants
- Add src/errors/messages.ts: all user-facing error message strings
- Add tests/unit/errors/index.test.ts: 23 tests, 100% coverage
- Remove passWithNoTests from vitest.config.ts (scaffolding phase complete)
- Delete tests/unit/index.test.ts (scaffolding placeholder)
- Fix tsconfig.test.json: add explicit exclude to override inherited tests/ exclusion
- Migrate ESLint config to flat config format (required by ESLint v10)
- Update .eslintrc.json to use tsconfig.test.json for type-aware linting