### PR TITLE
fix: correct CDK v1 detection to use library metadata not schema version

### DIFF
--- a/src/assembly/reader.ts
+++ b/src/assembly/reader.ts
@@ -9,12 +9,6 @@ import type { CloudAssembly, StackEnvironment, StackManifest } from './types.js'
 
 const CDK_STACK_ARTIFACT_TYPE = 'aws:cloudformation:stack';
 
-/**
- * CDK cloud assembly schema version 6 is the first version produced by CDK v2.
- * Any manifest with a major schema version below this threshold is CDK v1.
- */
-const MIN_CDK_V2_SCHEMA_MAJOR = 6;
-
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 function isValidManifestShape(
@@ -29,17 +23,87 @@ function isValidManifestShape(
 }
 
 /**
- * Returns true when the schema major version is below the CDK v2 threshold.
- * An unparseable version string is treated as unknown and returns false
- * (the reader will attempt to continue rather than block on a bad version).
+ * Returns true when the manifest artifacts contain runtimeInfo that
+ * positively identifies the assembly as CDK v1 — i.e. `@aws-cdk/core` is
+ * present in runtimeInfo.libraries without `aws-cdk-lib`.
+ *
+ * The schema version number alone cannot distinguish CDK v1 from v2: CDK v1
+ * produced schema versions well above 6 (e.g. v1.139.0 → schema 16.0.0).
+ * The library-based check is the only reliable signal.
+ *
+ * Returns false (assume CDK v2) when:
+ * - `aws-cdk-lib` is found anywhere → definitely CDK v2
+ * - runtimeInfo or libraries fields are absent → modern assemblies may omit them
+ * - No positive evidence of CDK v1 is found after walking all artifacts
  */
-function isCdkV1Schema(version: string): boolean {
-  // split('.', 1).join('') extracts the major version segment as a plain string,
-  // avoiding noUncheckedIndexedAccess dead branches on array[0] ?? fallback.
-  const majorStr = version.split('.', 1).join('');
-  const major = parseInt(majorStr, 10);
-  if (isNaN(major)) return false;
-  return major < MIN_CDK_V2_SCHEMA_MAJOR;
+function isCdkV1Assembly(artifacts: Record<string, unknown>): boolean {
+  for (const artifactKey of Object.keys(artifacts)) {
+    const artifact = artifacts[artifactKey];
+    if (typeof artifact !== 'object' || artifact === null) continue;
+
+    const artifactRecord = artifact as Record<string, unknown>;
+    const metadata = Object.prototype.hasOwnProperty.call(
+      artifactRecord,
+      'metadata',
+    )
+      ? artifactRecord['metadata']
+      : undefined;
+
+    if (typeof metadata !== 'object' || metadata === null) continue;
+
+    const metadataRecord = metadata as Record<string, unknown>;
+
+    for (const metaPath of Object.keys(metadataRecord)) {
+      const entries = metadataRecord[metaPath];
+      if (!Array.isArray(entries)) continue;
+
+      for (const entry of entries) {
+        if (typeof entry !== 'object' || entry === null) continue;
+
+        const entryRecord = entry as Record<string, unknown>;
+        const data = Object.prototype.hasOwnProperty.call(entryRecord, 'data')
+          ? entryRecord['data']
+          : undefined;
+
+        if (typeof data !== 'object' || data === null) continue;
+
+        const dataRecord = data as Record<string, unknown>;
+        const runtimeInfo = Object.prototype.hasOwnProperty.call(
+          dataRecord,
+          'runtimeInfo',
+        )
+          ? dataRecord['runtimeInfo']
+          : undefined;
+
+        if (typeof runtimeInfo !== 'object' || runtimeInfo === null) continue;
+
+        const runtimeRecord = runtimeInfo as Record<string, unknown>;
+        const libraries = Object.prototype.hasOwnProperty.call(
+          runtimeRecord,
+          'libraries',
+        )
+          ? runtimeRecord['libraries']
+          : undefined;
+
+        if (typeof libraries !== 'object' || libraries === null) continue;
+
+        const libRecord = libraries as Record<string, unknown>;
+
+        // aws-cdk-lib present → definitely CDK v2, stop searching
+        if (Object.prototype.hasOwnProperty.call(libRecord, 'aws-cdk-lib')) {
+          return false;
+        }
+
+        // @aws-cdk/core without aws-cdk-lib → CDK v1
+        if (Object.prototype.hasOwnProperty.call(libRecord, '@aws-cdk/core')) {
+          return true;
+        }
+      }
+    }
+  }
+
+  // No runtimeInfo or no recognisable library markers found → assume CDK v2
+  return false;
 }
 
 /**
@@ -184,7 +248,12 @@ export function readAssembly(dir: string): CloudAssembly {
   }
 
   // ── 5. Detect CDK v1 (ADR-007) ───────────────────────────────────────────
-  if (isCdkV1Schema(parsed.version)) {
+  const artifactsMap =
+    typeof parsed.artifacts === 'object' && parsed.artifacts !== null
+      ? (parsed.artifacts as Record<string, unknown>)
+      : {};
+
+  if (isCdkV1Assembly(artifactsMap)) {
     throw new StackPriceError(
       cdkV1Detected(parsed.version),
       EXIT_CODES.FAILURE,
@@ -192,11 +261,7 @@ export function readAssembly(dir: string): CloudAssembly {
   }
 
   // ── 6. Extract stacks from artifacts ─────────────────────────────────────
-  const stacks =
-    typeof parsed.artifacts === 'object' &&
-    parsed.artifacts !== null
-      ? extractStacks(parsed.artifacts as Record<string, unknown>)
-      : [];
+  const stacks = extractStacks(artifactsMap);
 
   return {
     version: parsed.version,

--- a/tests/unit/assembly/reader.test.ts
+++ b/tests/unit/assembly/reader.test.ts
@@ -41,14 +41,32 @@ const VALID_V2_MANIFEST_SINGLE_STACK = {
   },
 };
 
+// CDK v1 manifests are detected via runtimeInfo.libraries containing
+// @aws-cdk/core without aws-cdk-lib, not by schema version number.
+// CDK v1 produced schema versions well above 6 (e.g. v1.139.0 → schema 16.0.0).
 const CDK_V1_MANIFEST = {
-  version: '5.0.0',
+  version: '16.0.0',
   artifacts: {
     MyStack: {
       type: 'aws:cloudformation:stack',
       environment: 'aws://123456789012/us-east-1',
       properties: {
         templateFile: 'MyStack.template.json',
+      },
+      metadata: {
+        '/MyStack': [
+          {
+            type: 'aws:cdk:app',
+            data: {
+              runtimeInfo: {
+                libraries: {
+                  '@aws-cdk/core': '1.139.0',
+                  '@aws-cdk/aws-s3': '1.139.0',
+                },
+              },
+            },
+          },
+        ],
       },
     },
   },
@@ -231,7 +249,7 @@ describe('readAssembly', () => {
   });
 
   describe('CDK v1 detection — ADR-007', () => {
-    it('throws StackPriceError for schema version 5.0.0', () => {
+    it('throws StackPriceError when @aws-cdk/core is present without aws-cdk-lib', () => {
       const dir = makeTempDir(CDK_V1_MANIFEST);
       expect(() => readAssembly(dir)).toThrow(StackPriceError);
     });
@@ -248,7 +266,7 @@ describe('readAssembly', () => {
       expect((caught as StackPriceError).exitCode).toBe(2);
     });
 
-    it('includes the detected schema version in the error message', () => {
+    it('includes the schema version in the error message', () => {
       const dir = makeTempDir(CDK_V1_MANIFEST);
       let caught: unknown;
       try {
@@ -256,21 +274,69 @@ describe('readAssembly', () => {
       } catch (err) {
         caught = err;
       }
-      expect((caught as StackPriceError).message).toContain('5.0.0');
+      // CDK_V1_MANIFEST has schema version '16.0.0' — a version CDK v1 actually produced
+      expect((caught as StackPriceError).message).toContain('16.0.0');
     });
 
-    it('throws for schema version 1.0.0 (older CDK v1)', () => {
-      const dir = makeTempDir({ ...CDK_V1_MANIFEST, version: '1.0.0' });
+    it('throws for high schema version when @aws-cdk/core is present (old detection was wrong)', () => {
+      // This test proves the old schema-version < 6 check was incorrect:
+      // CDK v1 produced schema versions like 16.0.0, 20.0.0, etc.
+      const v1HighSchemaManifest = {
+        ...CDK_V1_MANIFEST,
+        version: '20.0.0',
+      };
+      const dir = makeTempDir(v1HighSchemaManifest);
       expect(() => readAssembly(dir)).toThrow(StackPriceError);
     });
 
-    it('does NOT throw for schema version 6.0.0 (CDK v2 boundary)', () => {
+    it('does NOT throw when aws-cdk-lib is present (CDK v2)', () => {
+      const dir = makeTempDir(VALID_V2_MANIFEST);
+      expect(() => readAssembly(dir)).not.toThrow();
+    });
+
+    it('does NOT throw when aws-cdk-lib and @aws-cdk/core are both present (aws-cdk-lib wins)', () => {
+      const mixedLibManifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [
+                {
+                  type: 'aws:cdk:app',
+                  data: {
+                    runtimeInfo: {
+                      libraries: {
+                        'aws-cdk-lib': '2.100.0',
+                        '@aws-cdk/core': '1.139.0', // transitional/compat layer
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(mixedLibManifest);
+      expect(() => readAssembly(dir)).not.toThrow();
+    });
+
+    it('does NOT throw when runtimeInfo is absent (defaults to CDK v2)', () => {
+      // Modern assemblies may omit runtimeInfo entirely — assume v2
       const dir = makeTempDir(EXACT_BOUNDARY_VERSION_6);
       expect(() => readAssembly(dir)).not.toThrow();
     });
 
-    it('does NOT throw for schema version 36.0.0 (CDK v2)', () => {
-      const dir = makeTempDir(VALID_V2_MANIFEST);
+    it('does NOT throw when artifacts have no metadata field (defaults to CDK v2)', () => {
+      const dir = makeTempDir(VALID_V2_MANIFEST_SINGLE_STACK);
+      expect(() => readAssembly(dir)).not.toThrow();
+    });
+
+    it('does NOT throw when manifest has no artifacts (defaults to CDK v2)', () => {
+      const dir = makeTempDir(MANIFEST_NO_ARTIFACTS);
       expect(() => readAssembly(dir)).not.toThrow();
     });
   });
@@ -412,20 +478,211 @@ describe('readAssembly', () => {
     });
   });
 
-  // ── Branch coverage: isCdkV1Schema ────────────────────────────────────────
+  // ── Branch coverage: isCdkV1Assembly ─────────────────────────────────────
 
-  describe('manifest with non-numeric version string', () => {
-    it('does not treat non-numeric version as CDK v1 (does not throw CDK v1 error)', () => {
-      // isNaN branch: parseInt("abc", 10) = NaN → isCdkV1Schema returns false
+  describe('isCdkV1Assembly branch coverage', () => {
+    it('does not throw for a manifest with non-numeric version and no library markers', () => {
+      // Non-numeric version strings are valid — schema version is not used for detection
       const dir = makeTempDir({ version: 'abc.0.0', artifacts: {} });
       const result = readAssembly(dir);
       expect(result.version).toBe('abc.0.0');
     });
 
-    it('returns empty stacks for a manifest with non-numeric version and no stacks', () => {
-      const dir = makeTempDir({ version: 'abc.0.0', artifacts: {} });
+    it('skips artifacts with non-array metadata entries', () => {
+      // metadataRecord[metaPath] is not an array → continue branch
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': 'not-an-array', // non-array → skipped
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
       const result = readAssembly(dir);
-      expect(result.stacks).toHaveLength(0);
+      expect(result.stacks).toHaveLength(1);
+    });
+
+    it('skips metadata entries with null data field', () => {
+      // data === null → continue branch
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [{ type: 'aws:cdk:app', data: null }],
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
+      const result = readAssembly(dir);
+      expect(result.stacks).toHaveLength(1);
+    });
+
+    it('skips metadata entries with non-object runtimeInfo', () => {
+      // runtimeInfo is a string → not object → continue branch
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [
+                { type: 'aws:cdk:app', data: { runtimeInfo: 'not-an-object' } },
+              ],
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
+      const result = readAssembly(dir);
+      expect(result.stacks).toHaveLength(1);
+    });
+
+    it('skips metadata entries with null libraries field', () => {
+      // libraries === null → continue branch
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [
+                {
+                  type: 'aws:cdk:app',
+                  data: { runtimeInfo: { libraries: null } },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
+      const result = readAssembly(dir);
+      expect(result.stacks).toHaveLength(1);
+    });
+
+    it('skips a null entry in the metadata entries array', () => {
+      // typeof entry !== 'object' || entry === null → continue branch (null case)
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [null],
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
+      const result = readAssembly(dir);
+      expect(result.stacks).toHaveLength(1);
+    });
+
+    it('skips a metadata entry that has no data property', () => {
+      // hasOwnProperty('data') → false → data = undefined → typeof !== 'object' → continue
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [{ type: 'aws:cdk:asset' }], // no data field
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
+      const result = readAssembly(dir);
+      expect(result.stacks).toHaveLength(1);
+    });
+
+    it('skips a metadata entry where data has no runtimeInfo property', () => {
+      // hasOwnProperty('runtimeInfo') → false → runtimeInfo = undefined → typeof !== 'object' → continue
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [{ type: 'aws:cdk:app', data: { otherField: true } }],
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
+      const result = readAssembly(dir);
+      expect(result.stacks).toHaveLength(1);
+    });
+
+    it('skips a metadata entry where runtimeInfo has no libraries property', () => {
+      // hasOwnProperty('libraries') → false → libraries = undefined → typeof !== 'object' → continue
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [
+                { type: 'aws:cdk:app', data: { runtimeInfo: { version: '2.0.0' } } },
+              ],
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
+      const result = readAssembly(dir);
+      expect(result.stacks).toHaveLength(1);
+    });
+
+    it('does NOT throw when libraries contains neither aws-cdk-lib nor @aws-cdk/core', () => {
+      // Both hasOwnProperty checks return false → falls through → returns false (assume v2)
+      const manifest = {
+        version: '36.0.0',
+        artifacts: {
+          MyStack: {
+            type: 'aws:cloudformation:stack',
+            environment: 'aws://123456789012/us-east-1',
+            properties: { templateFile: 'MyStack.template.json' },
+            metadata: {
+              '/MyStack': [
+                {
+                  type: 'aws:cdk:app',
+                  data: {
+                    runtimeInfo: {
+                      libraries: { 'some-other-lib': '1.0.0' },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      };
+      const dir = makeTempDir(manifest);
+      expect(() => readAssembly(dir)).not.toThrow();
     });
   });
 


### PR DESCRIPTION
The old isCdkV1Schema check (major version < 6) was incorrect: CDK v1 produced schema versions well above 6 (e.g. v1.139.0 → schema 16.0.0), so real CDK v1 assemblies would silently pass through as v2.

Replace with isCdkV1Assembly, which walks artifact metadata and checks runtimeInfo.libraries for @aws-cdk/core (v1 signal) vs aws-cdk-lib (v2 signal). Defaults to v2 when runtimeInfo is absent, per ADR-007.

Tests updated to reflect library-based detection with full branch coverage (132 tests, 100% coverage).