### PR TITLE
feat: add Lambda, S3, SQS, SNS usage-based handlers

### DIFF
--- a/src/registry/handlers/lambda.ts
+++ b/src/registry/handlers/lambda.ts
@@ -1,0 +1,47 @@
+import type { ResourceRecord } from '../../template/types.js';
+import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
+import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
+import { REGION_TO_LOCATION } from '../handler.js';
+
+interface LambdaAttributes extends PricingAttributes {
+  memorySize: number;
+  architecture: string;
+}
+
+export const lambdaHandler: ResourceHandler = {
+  resourceType: 'AWS::Lambda::Function',
+  isUsageBased: true,
+
+  extractPricingAttributes(resource: ResourceRecord): PricingAttributes | null {
+    const { properties } = resource;
+
+    const memorySizeRaw = properties['MemorySize'];
+    const memorySize = typeof memorySizeRaw === 'number' ? memorySizeRaw : 128;
+
+    const architecturesRaw = properties['Architectures'];
+    let architecture = 'x86_64';
+    if (Array.isArray(architecturesRaw) && typeof architecturesRaw[0] === 'string') {
+      architecture = architecturesRaw[0];
+    }
+
+    return { memorySize, architecture } satisfies LambdaAttributes;
+  },
+
+  buildPricingQuery(attributes: PricingAttributes, region: string): PricingQuery {
+    const attrs = attributes as LambdaAttributes;
+    const location = REGION_TO_LOCATION[region] ?? region;
+
+    return {
+      serviceCode: 'AWSLambda',
+      filters: [
+        { field: 'group', value: 'AWS-Lambda-Duration' },
+        { field: 'memorysize', value: String(attrs.memorySize) },
+        { field: 'location', value: location },
+      ],
+    };
+  },
+
+  calculateMonthlyCost(_result: PricingApiResult): MonthlyPrice | null {
+    return null;
+  },
+};

--- a/src/registry/handlers/s3.ts
+++ b/src/registry/handlers/s3.ts
@@ -1,0 +1,33 @@
+import type { ResourceRecord } from '../../template/types.js';
+import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
+import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
+import { REGION_TO_LOCATION } from '../handler.js';
+
+interface S3Attributes extends PricingAttributes {
+  storageClass: string;
+}
+
+export const s3Handler: ResourceHandler = {
+  resourceType: 'AWS::S3::Bucket',
+  isUsageBased: true,
+
+  extractPricingAttributes(_resource: ResourceRecord): PricingAttributes | null {
+    return { storageClass: 'STANDARD' } satisfies S3Attributes;
+  },
+
+  buildPricingQuery(_attributes: PricingAttributes, region: string): PricingQuery {
+    const location = REGION_TO_LOCATION[region] ?? region;
+
+    return {
+      serviceCode: 'AmazonS3',
+      filters: [
+        { field: 'volumeType', value: 'Standard' },
+        { field: 'location', value: location },
+      ],
+    };
+  },
+
+  calculateMonthlyCost(_result: PricingApiResult): MonthlyPrice | null {
+    return null;
+  },
+};

--- a/src/registry/handlers/sns.ts
+++ b/src/registry/handlers/sns.ts
@@ -1,0 +1,38 @@
+import type { ResourceRecord } from '../../template/types.js';
+import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
+import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
+import { REGION_TO_LOCATION } from '../handler.js';
+
+interface SnsAttributes extends PricingAttributes {
+  topicType: string;
+}
+
+export const snsHandler: ResourceHandler = {
+  resourceType: 'AWS::SNS::Topic',
+  isUsageBased: true,
+
+  extractPricingAttributes(resource: ResourceRecord): PricingAttributes | null {
+    const { properties } = resource;
+
+    const fifoRaw = properties['FifoTopic'];
+    const topicType = fifoRaw === true ? 'FIFO' : 'Standard';
+
+    return { topicType } satisfies SnsAttributes;
+  },
+
+  buildPricingQuery(_attributes: PricingAttributes, region: string): PricingQuery {
+    const location = REGION_TO_LOCATION[region] ?? region;
+
+    return {
+      serviceCode: 'AmazonSNS',
+      filters: [
+        { field: 'group', value: 'SNS-Requests-Tier1' },
+        { field: 'location', value: location },
+      ],
+    };
+  },
+
+  calculateMonthlyCost(_result: PricingApiResult): MonthlyPrice | null {
+    return null;
+  },
+};

--- a/src/registry/handlers/sqs.ts
+++ b/src/registry/handlers/sqs.ts
@@ -1,0 +1,39 @@
+import type { ResourceRecord } from '../../template/types.js';
+import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
+import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
+import { REGION_TO_LOCATION } from '../handler.js';
+
+interface SqsAttributes extends PricingAttributes {
+  queueType: string;
+}
+
+export const sqsHandler: ResourceHandler = {
+  resourceType: 'AWS::SQS::Queue',
+  isUsageBased: true,
+
+  extractPricingAttributes(resource: ResourceRecord): PricingAttributes | null {
+    const { properties } = resource;
+
+    const fifoRaw = properties['FifoQueue'];
+    const queueType = fifoRaw === true ? 'FIFO' : 'Standard';
+
+    return { queueType } satisfies SqsAttributes;
+  },
+
+  buildPricingQuery(attributes: PricingAttributes, region: string): PricingQuery {
+    const attrs = attributes as SqsAttributes;
+    const location = REGION_TO_LOCATION[region] ?? region;
+
+    return {
+      serviceCode: 'AWSQueueService',
+      filters: [
+        { field: 'queueType', value: attrs.queueType },
+        { field: 'location', value: location },
+      ],
+    };
+  },
+
+  calculateMonthlyCost(_result: PricingApiResult): MonthlyPrice | null {
+    return null;
+  },
+};

--- a/tests/unit/registry/handlers/lambda.test.ts
+++ b/tests/unit/registry/handlers/lambda.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+import { lambdaHandler } from '../../../../src/registry/handlers/lambda.js';
+import type { ResourceRecord } from '../../../../src/template/types.js';
+import type { PricingApiResult } from '../../../../src/pricing/types.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(properties: Record<string, unknown>): ResourceRecord {
+  return { logicalId: 'MyFunction', type: 'AWS::Lambda::Function', properties };
+}
+
+function makeResult(overrides: Partial<PricingApiResult> = {}): PricingApiResult {
+  return { pricePerUnit: 0.0000166667, unit: 'Lambda-GB-Second', currency: 'USD', ...overrides };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('lambdaHandler', () => {
+  it('has the correct resourceType', () => {
+    expect(lambdaHandler.resourceType).toBe('AWS::Lambda::Function');
+  });
+
+  it('is usage-based', () => {
+    expect(lambdaHandler.isUsageBased).toBe(true);
+  });
+
+  // ─── extractPricingAttributes ───────────────────────────────────────────────
+
+  describe('extractPricingAttributes', () => {
+    it('returns attributes for a valid resource with explicit values', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(
+        makeResource({ MemorySize: 512, Architectures: ['arm64'] }),
+      );
+      expect(attrs).not.toBeNull();
+      expect(attrs!['memorySize']).toBe(512);
+      expect(attrs!['architecture']).toBe('arm64');
+    });
+
+    it('defaults MemorySize to 128 when absent', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(makeResource({}));
+      expect(attrs).not.toBeNull();
+      expect(attrs!['memorySize']).toBe(128);
+    });
+
+    it('defaults MemorySize to 128 when wrong type', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(
+        makeResource({ MemorySize: 'big' }),
+      );
+      expect(attrs!['memorySize']).toBe(128);
+    });
+
+    it('defaults architecture to x86_64 when Architectures is absent', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(makeResource({}));
+      expect(attrs!['architecture']).toBe('x86_64');
+    });
+
+    it('defaults architecture to x86_64 when Architectures is not an array', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(
+        makeResource({ Architectures: 'arm64' }),
+      );
+      expect(attrs!['architecture']).toBe('x86_64');
+    });
+
+    it('defaults architecture to x86_64 when Architectures is an empty array', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(
+        makeResource({ Architectures: [] }),
+      );
+      expect(attrs!['architecture']).toBe('x86_64');
+    });
+
+    it('picks architecture from first element of Architectures array', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(
+        makeResource({ Architectures: ['arm64'] }),
+      );
+      expect(attrs!['architecture']).toBe('arm64');
+    });
+  });
+
+  // ─── buildPricingQuery ──────────────────────────────────────────────────────
+
+  describe('buildPricingQuery', () => {
+    it('uses serviceCode AWSLambda', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(makeResource({}))!;
+      const query = lambdaHandler.buildPricingQuery(attrs, 'us-east-1');
+      expect(query.serviceCode).toBe('AWSLambda');
+    });
+
+    it('includes group=AWS-Lambda-Duration filter', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(makeResource({}))!;
+      const query = lambdaHandler.buildPricingQuery(attrs, 'us-east-1');
+      const fields = Object.fromEntries(query.filters.map((f) => [f.field, f.value]));
+      expect(fields['group']).toBe('AWS-Lambda-Duration');
+    });
+
+    it('includes memorysize filter with string value', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(
+        makeResource({ MemorySize: 256 }),
+      )!;
+      const query = lambdaHandler.buildPricingQuery(attrs, 'us-east-1');
+      const fields = Object.fromEntries(query.filters.map((f) => [f.field, f.value]));
+      expect(fields['memorysize']).toBe('256');
+    });
+
+    it('maps us-east-1 to the correct location name', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(makeResource({}))!;
+      const query = lambdaHandler.buildPricingQuery(attrs, 'us-east-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('US East (N. Virginia)');
+    });
+
+    it('maps eu-central-1 to Europe (Frankfurt)', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(makeResource({}))!;
+      const query = lambdaHandler.buildPricingQuery(attrs, 'eu-central-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('Europe (Frankfurt)');
+    });
+
+    it('passes through unknown regions unchanged', () => {
+      const attrs = lambdaHandler.extractPricingAttributes(makeResource({}))!;
+      const query = lambdaHandler.buildPricingQuery(attrs, 'xx-unknown-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('xx-unknown-1');
+    });
+  });
+
+  // ─── calculateMonthlyCost ───────────────────────────────────────────────────
+
+  describe('calculateMonthlyCost', () => {
+    it('returns null — usage-based handler', () => {
+      expect(lambdaHandler.calculateMonthlyCost(makeResult())).toBeNull();
+    });
+
+    it('returns null regardless of unit', () => {
+      expect(lambdaHandler.calculateMonthlyCost(makeResult({ unit: 'Hrs' }))).toBeNull();
+    });
+
+    it('returns null regardless of pricePerUnit value', () => {
+      expect(lambdaHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 }))).toBeNull();
+    });
+  });
+});

--- a/tests/unit/registry/handlers/s3.test.ts
+++ b/tests/unit/registry/handlers/s3.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { s3Handler } from '../../../../src/registry/handlers/s3.js';
+import type { ResourceRecord } from '../../../../src/template/types.js';
+import type { PricingApiResult } from '../../../../src/pricing/types.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(properties: Record<string, unknown>): ResourceRecord {
+  return { logicalId: 'MyBucket', type: 'AWS::S3::Bucket', properties };
+}
+
+function makeResult(overrides: Partial<PricingApiResult> = {}): PricingApiResult {
+  return { pricePerUnit: 0.023, unit: 'GB-Mo', currency: 'USD', ...overrides };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('s3Handler', () => {
+  it('has the correct resourceType', () => {
+    expect(s3Handler.resourceType).toBe('AWS::S3::Bucket');
+  });
+
+  it('is usage-based', () => {
+    expect(s3Handler.isUsageBased).toBe(true);
+  });
+
+  // ─── extractPricingAttributes ───────────────────────────────────────────────
+
+  describe('extractPricingAttributes', () => {
+    it('always returns STANDARD storageClass regardless of properties', () => {
+      const attrs = s3Handler.extractPricingAttributes(makeResource({}));
+      expect(attrs).not.toBeNull();
+      expect(attrs!['storageClass']).toBe('STANDARD');
+    });
+
+    it('returns STANDARD even when resource has additional properties', () => {
+      const attrs = s3Handler.extractPricingAttributes(
+        makeResource({ BucketName: 'my-bucket', VersioningConfiguration: { Status: 'Enabled' } }),
+      );
+      expect(attrs!['storageClass']).toBe('STANDARD');
+    });
+  });
+
+  // ─── buildPricingQuery ──────────────────────────────────────────────────────
+
+  describe('buildPricingQuery', () => {
+    it('uses serviceCode AmazonS3', () => {
+      const attrs = s3Handler.extractPricingAttributes(makeResource({}))!;
+      const query = s3Handler.buildPricingQuery(attrs, 'us-east-1');
+      expect(query.serviceCode).toBe('AmazonS3');
+    });
+
+    it('includes volumeType=Standard filter', () => {
+      const attrs = s3Handler.extractPricingAttributes(makeResource({}))!;
+      const query = s3Handler.buildPricingQuery(attrs, 'us-east-1');
+      const fields = Object.fromEntries(query.filters.map((f) => [f.field, f.value]));
+      expect(fields['volumeType']).toBe('Standard');
+    });
+
+    it('maps us-east-1 to the correct location name', () => {
+      const attrs = s3Handler.extractPricingAttributes(makeResource({}))!;
+      const query = s3Handler.buildPricingQuery(attrs, 'us-east-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('US East (N. Virginia)');
+    });
+
+    it('maps ap-northeast-1 to Asia Pacific (Tokyo)', () => {
+      const attrs = s3Handler.extractPricingAttributes(makeResource({}))!;
+      const query = s3Handler.buildPricingQuery(attrs, 'ap-northeast-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('Asia Pacific (Tokyo)');
+    });
+
+    it('passes through unknown regions unchanged', () => {
+      const attrs = s3Handler.extractPricingAttributes(makeResource({}))!;
+      const query = s3Handler.buildPricingQuery(attrs, 'xx-unknown-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('xx-unknown-1');
+    });
+  });
+
+  // ─── calculateMonthlyCost ───────────────────────────────────────────────────
+
+  describe('calculateMonthlyCost', () => {
+    it('returns null — usage-based handler', () => {
+      expect(s3Handler.calculateMonthlyCost(makeResult())).toBeNull();
+    });
+
+    it('returns null regardless of unit', () => {
+      expect(s3Handler.calculateMonthlyCost(makeResult({ unit: 'Hrs' }))).toBeNull();
+    });
+
+    it('returns null regardless of pricePerUnit value', () => {
+      expect(s3Handler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 }))).toBeNull();
+    });
+  });
+});

--- a/tests/unit/registry/handlers/sns.test.ts
+++ b/tests/unit/registry/handlers/sns.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { snsHandler } from '../../../../src/registry/handlers/sns.js';
+import type { ResourceRecord } from '../../../../src/template/types.js';
+import type { PricingApiResult } from '../../../../src/pricing/types.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(properties: Record<string, unknown>): ResourceRecord {
+  return { logicalId: 'MyTopic', type: 'AWS::SNS::Topic', properties };
+}
+
+function makeResult(overrides: Partial<PricingApiResult> = {}): PricingApiResult {
+  return { pricePerUnit: 0.0000005, unit: 'Requests', currency: 'USD', ...overrides };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('snsHandler', () => {
+  it('has the correct resourceType', () => {
+    expect(snsHandler.resourceType).toBe('AWS::SNS::Topic');
+  });
+
+  it('is usage-based', () => {
+    expect(snsHandler.isUsageBased).toBe(true);
+  });
+
+  // ─── extractPricingAttributes ───────────────────────────────────────────────
+
+  describe('extractPricingAttributes', () => {
+    it('returns Standard topicType when FifoTopic is absent', () => {
+      const attrs = snsHandler.extractPricingAttributes(makeResource({}));
+      expect(attrs).not.toBeNull();
+      expect(attrs!['topicType']).toBe('Standard');
+    });
+
+    it('returns Standard topicType when FifoTopic is false', () => {
+      const attrs = snsHandler.extractPricingAttributes(
+        makeResource({ FifoTopic: false }),
+      );
+      expect(attrs!['topicType']).toBe('Standard');
+    });
+
+    it('returns FIFO topicType when FifoTopic is true', () => {
+      const attrs = snsHandler.extractPricingAttributes(
+        makeResource({ FifoTopic: true }),
+      );
+      expect(attrs!['topicType']).toBe('FIFO');
+    });
+
+    it('returns Standard when FifoTopic has wrong type', () => {
+      const attrs = snsHandler.extractPricingAttributes(
+        makeResource({ FifoTopic: 'true' }),
+      );
+      expect(attrs!['topicType']).toBe('Standard');
+    });
+  });
+
+  // ─── buildPricingQuery ──────────────────────────────────────────────────────
+
+  describe('buildPricingQuery', () => {
+    it('uses serviceCode AmazonSNS', () => {
+      const attrs = snsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = snsHandler.buildPricingQuery(attrs, 'us-east-1');
+      expect(query.serviceCode).toBe('AmazonSNS');
+    });
+
+    it('includes group=SNS-Requests-Tier1 filter', () => {
+      const attrs = snsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = snsHandler.buildPricingQuery(attrs, 'us-east-1');
+      const fields = Object.fromEntries(query.filters.map((f) => [f.field, f.value]));
+      expect(fields['group']).toBe('SNS-Requests-Tier1');
+    });
+
+    it('maps us-east-1 to the correct location name', () => {
+      const attrs = snsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = snsHandler.buildPricingQuery(attrs, 'us-east-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('US East (N. Virginia)');
+    });
+
+    it('maps sa-east-1 to South America (Sao Paulo)', () => {
+      const attrs = snsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = snsHandler.buildPricingQuery(attrs, 'sa-east-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('South America (Sao Paulo)');
+    });
+
+    it('passes through unknown regions unchanged', () => {
+      const attrs = snsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = snsHandler.buildPricingQuery(attrs, 'xx-unknown-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('xx-unknown-1');
+    });
+  });
+
+  // ─── calculateMonthlyCost ───────────────────────────────────────────────────
+
+  describe('calculateMonthlyCost', () => {
+    it('returns null — usage-based handler', () => {
+      expect(snsHandler.calculateMonthlyCost(makeResult())).toBeNull();
+    });
+
+    it('returns null regardless of unit', () => {
+      expect(snsHandler.calculateMonthlyCost(makeResult({ unit: 'Hrs' }))).toBeNull();
+    });
+
+    it('returns null regardless of pricePerUnit value', () => {
+      expect(snsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 }))).toBeNull();
+    });
+  });
+});

--- a/tests/unit/registry/handlers/sqs.test.ts
+++ b/tests/unit/registry/handlers/sqs.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import { sqsHandler } from '../../../../src/registry/handlers/sqs.js';
+import type { ResourceRecord } from '../../../../src/template/types.js';
+import type { PricingApiResult } from '../../../../src/pricing/types.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(properties: Record<string, unknown>): ResourceRecord {
+  return { logicalId: 'MyQueue', type: 'AWS::SQS::Queue', properties };
+}
+
+function makeResult(overrides: Partial<PricingApiResult> = {}): PricingApiResult {
+  return { pricePerUnit: 0.0000004, unit: 'Requests', currency: 'USD', ...overrides };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('sqsHandler', () => {
+  it('has the correct resourceType', () => {
+    expect(sqsHandler.resourceType).toBe('AWS::SQS::Queue');
+  });
+
+  it('is usage-based', () => {
+    expect(sqsHandler.isUsageBased).toBe(true);
+  });
+
+  // ─── extractPricingAttributes ───────────────────────────────────────────────
+
+  describe('extractPricingAttributes', () => {
+    it('returns Standard queueType when FifoQueue is absent', () => {
+      const attrs = sqsHandler.extractPricingAttributes(makeResource({}));
+      expect(attrs).not.toBeNull();
+      expect(attrs!['queueType']).toBe('Standard');
+    });
+
+    it('returns Standard queueType when FifoQueue is false', () => {
+      const attrs = sqsHandler.extractPricingAttributes(
+        makeResource({ FifoQueue: false }),
+      );
+      expect(attrs!['queueType']).toBe('Standard');
+    });
+
+    it('returns FIFO queueType when FifoQueue is true', () => {
+      const attrs = sqsHandler.extractPricingAttributes(
+        makeResource({ FifoQueue: true }),
+      );
+      expect(attrs!['queueType']).toBe('FIFO');
+    });
+
+    it('returns Standard when FifoQueue has wrong type', () => {
+      const attrs = sqsHandler.extractPricingAttributes(
+        makeResource({ FifoQueue: 'yes' }),
+      );
+      expect(attrs!['queueType']).toBe('Standard');
+    });
+  });
+
+  // ─── buildPricingQuery ──────────────────────────────────────────────────────
+
+  describe('buildPricingQuery', () => {
+    it('uses serviceCode AWSQueueService', () => {
+      const attrs = sqsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = sqsHandler.buildPricingQuery(attrs, 'us-east-1');
+      expect(query.serviceCode).toBe('AWSQueueService');
+    });
+
+    it('includes queueType=Standard filter for standard queue', () => {
+      const attrs = sqsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = sqsHandler.buildPricingQuery(attrs, 'us-east-1');
+      const fields = Object.fromEntries(query.filters.map((f) => [f.field, f.value]));
+      expect(fields['queueType']).toBe('Standard');
+    });
+
+    it('includes queueType=FIFO filter for FIFO queue', () => {
+      const attrs = sqsHandler.extractPricingAttributes(
+        makeResource({ FifoQueue: true }),
+      )!;
+      const query = sqsHandler.buildPricingQuery(attrs, 'us-east-1');
+      const fields = Object.fromEntries(query.filters.map((f) => [f.field, f.value]));
+      expect(fields['queueType']).toBe('FIFO');
+    });
+
+    it('maps us-east-1 to the correct location name', () => {
+      const attrs = sqsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = sqsHandler.buildPricingQuery(attrs, 'us-east-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('US East (N. Virginia)');
+    });
+
+    it('maps us-west-2 to US West (Oregon)', () => {
+      const attrs = sqsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = sqsHandler.buildPricingQuery(attrs, 'us-west-2');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('US West (Oregon)');
+    });
+
+    it('passes through unknown regions unchanged', () => {
+      const attrs = sqsHandler.extractPricingAttributes(makeResource({}))!;
+      const query = sqsHandler.buildPricingQuery(attrs, 'xx-unknown-1');
+      const loc = query.filters.find((f) => f.field === 'location')?.value;
+      expect(loc).toBe('xx-unknown-1');
+    });
+  });
+
+  // ─── calculateMonthlyCost ───────────────────────────────────────────────────
+
+  describe('calculateMonthlyCost', () => {
+    it('returns null — usage-based handler', () => {
+      expect(sqsHandler.calculateMonthlyCost(makeResult())).toBeNull();
+    });
+
+    it('returns null regardless of unit', () => {
+      expect(sqsHandler.calculateMonthlyCost(makeResult({ unit: 'Hrs' }))).toBeNull();
+    });
+
+    it('returns null regardless of pricePerUnit value', () => {
+      expect(sqsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 }))).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Implements the four remaining usage-based resource handlers for module 8: AWS::Lambda::Function, AWS::S3::Bucket, AWS::SQS::Queue, AWS::SNS::Topic. All return null from calculateMonthlyCost (unit price only, no monthly total). 100% branch/statement/function coverage across all four handlers.