### PR TITLE
feat: implement table, JSON, and summary output formatters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "@aws-sdk/client-pricing": "^3.1023.0",
         "@aws-sdk/credential-providers": "^3.1023.0",
+        "chalk": "^4.1.2",
+        "cli-table3": "^0.6.5",
         "env-paths": "^4.0.0"
       },
       "bin": {
@@ -791,6 +793,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2783,6 +2795,30 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2844,6 +2880,55 @@
         "node": ">=18"
       }
     },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -2900,6 +2985,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/env-paths": {
       "version": "4.0.0",
@@ -3343,7 +3434,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3384,6 +3474,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -4162,6 +4261,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strnum": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.2.tgz",
@@ -4178,7 +4303,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
   "dependencies": {
     "@aws-sdk/client-pricing": "^3.1023.0",
     "@aws-sdk/credential-providers": "^3.1023.0",
+    "chalk": "^4.1.2",
+    "cli-table3": "^0.6.5",
     "env-paths": "^4.0.0"
   }
 }

--- a/src/output/json.ts
+++ b/src/output/json.ts
@@ -1,0 +1,96 @@
+import type { PricedStack } from '../pricing/types.js';
+import type {
+  BreakdownResult,
+  PricedStackResult,
+  ResourceResult,
+  UsageBasedResult,
+  ConditionalResult,
+  BreakdownSummary,
+} from './types.js';
+import packageJson from '../../package.json';
+
+function buildSummary(stacks: PricedStack[], executionTimeMs: number): BreakdownSummary {
+  let totalResources = 0;
+  let pricedResources = 0;
+  let usageBasedResources = 0;
+  let conditionalResources = 0;
+  let unsupportedResources = 0;
+
+  for (const stack of stacks) {
+    pricedResources += stack.pricedResources.length;
+    usageBasedResources += stack.usageBasedResources.length;
+    conditionalResources += stack.conditionalResources.length;
+    unsupportedResources += stack.unsupportedTypes.length;
+    totalResources +=
+      stack.pricedResources.length +
+      stack.usageBasedResources.length +
+      stack.conditionalResources.length;
+  }
+
+  return {
+    totalStacks: stacks.length,
+    totalResources,
+    pricedResources,
+    usageBasedResources,
+    conditionalResources,
+    unsupportedResources,
+    executionTimeMs,
+  };
+}
+
+function toStackResult(stack: PricedStack): PricedStackResult {
+  const resources: ResourceResult[] = stack.pricedResources.map((r) => ({
+    logicalId: r.logicalId,
+    type: r.type,
+    monthlyCost: r.monthlyCost,
+    currency: r.currency,
+    basis: r.basis,
+  }));
+
+  const usageBasedResources: UsageBasedResult[] = stack.usageBasedResources.map((r) => ({
+    logicalId: r.logicalId,
+    type: r.type,
+    unitPrice: r.unitPrice,
+    unit: r.unit,
+    currency: r.currency,
+    note: 'Usage-based — provide estimate via --usage-file',
+  }));
+
+  const conditionalResources: ConditionalResult[] = stack.conditionalResources.map((r) => ({
+    logicalId: r.logicalId,
+    type: r.type,
+    conditionName: r.conditionName,
+    monthlyCost: r.monthlyCost,
+    currency: r.currency,
+    note: 'Excluded from total — gated by CloudFormation Condition',
+  }));
+
+  return {
+    stackId: stack.stackId,
+    region: stack.region,
+    regionSource: stack.regionSource,
+    resources,
+    usageBasedResources,
+    conditionalResources,
+    unsupportedTypes: stack.unsupportedTypes,
+    stackMonthlyCost: stack.stackMonthlyCost,
+  };
+}
+
+export function formatJson(stacks: PricedStack[], startTime: number): string {
+  const now = Date.now();
+  const executionTimeMs = now - startTime;
+  const totalMonthlyCost = stacks.reduce((sum, s) => sum + s.stackMonthlyCost, 0);
+
+  const result: BreakdownResult = {
+    schemaVersion: '1.0',
+    timestamp: new Date().toISOString(),
+    stackpriceVersion: packageJson.version,
+    stacks: stacks.map(toStackResult),
+    totalMonthlyCost,
+    currency: 'USD',
+    summary: buildSummary(stacks, executionTimeMs),
+  };
+
+  return JSON.stringify(result, null, 2);
+}

--- a/src/output/summary.ts
+++ b/src/output/summary.ts
@@ -1,0 +1,33 @@
+import type { PricedStack } from '../pricing/types.js';
+
+export function formatSummary(stacks: PricedStack[], startTime: number): string {
+  const elapsedMs = Date.now() - startTime;
+  const elapsedSec = (elapsedMs / 1000).toFixed(1);
+
+  const totalMonthlyCost = stacks.reduce((sum, s) => sum + s.stackMonthlyCost, 0);
+  const totalStacks = stacks.length;
+  const pricedCount = stacks.reduce((sum, s) => sum + s.pricedResources.length, 0);
+  const usageBasedCount = stacks.reduce((sum, s) => sum + s.usageBasedResources.length, 0);
+
+  const onlyUsageBased = pricedCount === 0 && usageBasedCount > 0;
+  const costStr = onlyUsageBased ? 'N/A' : `$${totalMonthlyCost.toFixed(2)}/month`;
+
+  const parts: string[] = [
+    `TOTAL: ${costStr}`,
+  ];
+
+  if (usageBasedCount > 0) {
+    parts[0] += ' + usage-based';
+  }
+
+  parts.push(`${totalStacks} stack${totalStacks !== 1 ? 's' : ''}`);
+  parts.push(`${pricedCount} priced`);
+
+  if (usageBasedCount > 0) {
+    parts.push(`${usageBasedCount} usage-based`);
+  }
+
+  parts.push(`${elapsedSec}s`);
+
+  return parts.join(' · ');
+}

--- a/src/output/table.ts
+++ b/src/output/table.ts
@@ -1,0 +1,105 @@
+import Table from 'cli-table3';
+import chalk from 'chalk';
+import type { PricedStack } from '../pricing/types.js';
+
+function formatCost(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+function header(label: string, noColor: boolean): string {
+  return noColor ? label : chalk.bold(label);
+}
+
+function buildFixedTable(stack: PricedStack, noColor: boolean): string {
+  const sorted = [...stack.pricedResources].sort((a, b) => b.monthlyCost - a.monthlyCost);
+
+  const headStyle = noColor ? [] : ['cyan'];
+  const table = new Table({
+    head: ['Resource ID', 'Type', 'Monthly Cost'],
+    style: { head: headStyle },
+  });
+
+  for (const r of sorted) {
+    table.push([r.logicalId, r.type, formatCost(r.monthlyCost)]);
+  }
+
+  const subtotalLabel = noColor ? 'Stack Subtotal' : chalk.bold('Stack Subtotal');
+  table.push([{ content: subtotalLabel, colSpan: 2 }, formatCost(stack.stackMonthlyCost)]);
+
+  return table.toString();
+}
+
+function buildUsageTable(stack: PricedStack, noColor: boolean): string {
+  const headStyle = noColor ? [] : ['cyan'];
+  const table = new Table({
+    head: ['Resource ID', 'Type', 'Unit Price', 'Note'],
+    style: { head: headStyle },
+  });
+
+  for (const r of stack.usageBasedResources) {
+    table.push([r.logicalId, r.type, `$${r.unitPrice}/unit`, 'Usage-based — provide estimate via --usage-file']);
+  }
+
+  return table.toString();
+}
+
+function buildConditionalTable(stack: PricedStack, noColor: boolean): string {
+  const headStyle = noColor ? [] : ['cyan'];
+  const table = new Table({
+    head: ['Resource ID', 'Type', 'Condition', 'Monthly Cost'],
+    style: { head: headStyle },
+  });
+
+  for (const r of stack.conditionalResources) {
+    const costStr = r.monthlyCost !== null ? formatCost(r.monthlyCost) : 'Usage-based';
+    table.push([r.logicalId, r.type, r.conditionName, costStr]);
+  }
+
+  return table.toString();
+}
+
+export function formatTable(stacks: PricedStack[], noColor: boolean): string {
+  if (noColor) {
+    chalk.level = 0;
+  } else {
+    chalk.level = 3;
+  }
+
+  const totalMonthlyCost = stacks.reduce((sum, s) => sum + s.stackMonthlyCost, 0);
+  const hasUsageBased = stacks.some((s) => s.usageBasedResources.length > 0);
+
+  const lines: string[] = [];
+
+  for (const stack of stacks) {
+    const stackHeader = header(`Stack: ${stack.stackId}   Region: ${stack.region}`, noColor);
+    lines.push(stackHeader);
+
+    if (stack.pricedResources.length > 0) {
+      lines.push(buildFixedTable(stack, noColor));
+    }
+
+    if (stack.usageBasedResources.length > 0) {
+      lines.push(buildUsageTable(stack, noColor));
+    }
+
+    if (stack.conditionalResources.length > 0) {
+      lines.push(buildConditionalTable(stack, noColor));
+    }
+
+    if (stack.unsupportedTypes.length > 0) {
+      const label = noColor ? 'Unsupported types (not priced):' : chalk.yellow('Unsupported types (not priced):');
+      lines.push(`${label} ${stack.unsupportedTypes.join(', ')}`);
+    }
+
+    lines.push('');
+  }
+
+  const totalStr = formatCost(totalMonthlyCost) + (hasUsageBased ? ' + usage-based' : '');
+  const totalLine = noColor
+    ? `TOTAL ESTIMATED MONTHLY COST: ${totalStr}`
+    : chalk.bold(`TOTAL ESTIMATED MONTHLY COST: ${totalStr}`);
+
+  lines.push(totalLine);
+
+  return lines.join('\n');
+}

--- a/src/output/types.ts
+++ b/src/output/types.ts
@@ -1,0 +1,56 @@
+export interface BreakdownResult {
+  schemaVersion: '1.0';
+  timestamp: string;
+  stackpriceVersion: string;
+  stacks: PricedStackResult[];
+  totalMonthlyCost: number;
+  currency: 'USD';
+  summary: BreakdownSummary;
+}
+
+export interface PricedStackResult {
+  stackId: string;
+  region: string;
+  regionSource: string;
+  resources: ResourceResult[];
+  usageBasedResources: UsageBasedResult[];
+  conditionalResources: ConditionalResult[];
+  unsupportedTypes: string[];
+  stackMonthlyCost: number;
+}
+
+export interface ResourceResult {
+  logicalId: string;
+  type: string;
+  monthlyCost: number;
+  currency: 'USD';
+  basis: string;
+}
+
+export interface UsageBasedResult {
+  logicalId: string;
+  type: string;
+  unitPrice: number;
+  unit: string;
+  currency: 'USD';
+  note: 'Usage-based — provide estimate via --usage-file';
+}
+
+export interface ConditionalResult {
+  logicalId: string;
+  type: string;
+  conditionName: string;
+  monthlyCost: number | null;
+  currency: 'USD';
+  note: 'Excluded from total — gated by CloudFormation Condition';
+}
+
+export interface BreakdownSummary {
+  totalStacks: number;
+  totalResources: number;
+  pricedResources: number;
+  usageBasedResources: number;
+  conditionalResources: number;
+  unsupportedResources: number;
+  executionTimeMs: number;
+}

--- a/tests/unit/output/json.test.ts
+++ b/tests/unit/output/json.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PricedStack } from '../../../src/pricing/types.js';
+import type { BreakdownResult } from '../../../src/output/types.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeStack(overrides: Partial<PricedStack> = {}): PricedStack {
+  return {
+    stackId: 'MyStack',
+    region: 'us-east-1',
+    regionSource: 'template',
+    pricedResources: [
+      {
+        logicalId: 'Ec2Instance',
+        type: 'AWS::EC2::Instance',
+        monthlyCost: 70.08,
+        currency: 'USD',
+        basis: 'Hrs',
+      },
+    ],
+    usageBasedResources: [],
+    conditionalResources: [],
+    unsupportedTypes: [],
+    stackMonthlyCost: 70.08,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('formatJson', () => {
+  const FIXED_NOW = new Date('2025-06-01T12:00:00.000Z').getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns valid JSON that parses back to BreakdownResult shape', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const stacks = [makeStack()];
+    const output = formatJson(stacks, FIXED_NOW - 1200);
+
+    const parsed = JSON.parse(output) as BreakdownResult;
+    expect(parsed.schemaVersion).toBe('1.0');
+    expect(parsed.currency).toBe('USD');
+    expect(parsed.timestamp).toBe('2025-06-01T12:00:00.000Z');
+    expect(typeof parsed.stackpriceVersion).toBe('string');
+    expect(parsed.stackpriceVersion.length).toBeGreaterThan(0);
+    expect(Array.isArray(parsed.stacks)).toBe(true);
+    expect(typeof parsed.totalMonthlyCost).toBe('number');
+    expect(parsed.summary).toBeDefined();
+  });
+
+  it('maps a priced resource to ResourceResult shape', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const output = formatJson([makeStack()], FIXED_NOW);
+    const parsed = JSON.parse(output) as BreakdownResult;
+
+    const resource = parsed.stacks[0]!.resources[0]!;
+    expect(resource.logicalId).toBe('Ec2Instance');
+    expect(resource.type).toBe('AWS::EC2::Instance');
+    expect(resource.monthlyCost).toBe(70.08);
+    expect(resource.currency).toBe('USD');
+    expect(resource.basis).toBe('Hrs');
+  });
+
+  it('computes totalMonthlyCost as sum of stackMonthlyCosts', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const stack1 = makeStack({ stackId: 'Stack1', stackMonthlyCost: 50 });
+    const stack2 = makeStack({ stackId: 'Stack2', stackMonthlyCost: 122.65 });
+    const output = formatJson([stack1, stack2], FIXED_NOW);
+    const parsed = JSON.parse(output) as BreakdownResult;
+
+    expect(parsed.totalMonthlyCost).toBeCloseTo(172.65);
+  });
+
+  it('computes executionTimeMs from Date.now() - startTime', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const startTime = FIXED_NOW - 1500;
+    const output = formatJson([makeStack()], startTime);
+    const parsed = JSON.parse(output) as BreakdownResult;
+
+    expect(parsed.summary.executionTimeMs).toBe(1500);
+  });
+
+  it('handles empty stacks array gracefully', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const output = formatJson([], FIXED_NOW);
+    const parsed = JSON.parse(output) as BreakdownResult;
+
+    expect(parsed.stacks).toHaveLength(0);
+    expect(parsed.totalMonthlyCost).toBe(0);
+    expect(parsed.summary.totalStacks).toBe(0);
+    expect(parsed.summary.totalResources).toBe(0);
+  });
+
+  it('maps usage-based resources to UsageBasedResult shape', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const stack = makeStack({
+      pricedResources: [],
+      stackMonthlyCost: 0,
+      usageBasedResources: [
+        {
+          logicalId: 'MyLambda',
+          type: 'AWS::Lambda::Function',
+          unitPrice: 0.0000002,
+          unit: 'Requests',
+          currency: 'USD',
+        },
+      ],
+    });
+
+    const output = formatJson([stack], FIXED_NOW);
+    const parsed = JSON.parse(output) as BreakdownResult;
+
+    const ubr = parsed.stacks[0]!.usageBasedResources[0]!;
+    expect(ubr.logicalId).toBe('MyLambda');
+    expect(ubr.type).toBe('AWS::Lambda::Function');
+    expect(ubr.unitPrice).toBe(0.0000002);
+    expect(ubr.unit).toBe('Requests');
+    expect(ubr.currency).toBe('USD');
+    expect(ubr.note).toBe('Usage-based — provide estimate via --usage-file');
+  });
+
+  it('maps conditional resources to ConditionalResult shape (ADR-011)', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const stack = makeStack({
+      pricedResources: [],
+      stackMonthlyCost: 0,
+      conditionalResources: [
+        {
+          logicalId: 'ConditionalEc2',
+          type: 'AWS::EC2::Instance',
+          conditionName: 'IsProd',
+          monthlyCost: 70.08,
+          currency: 'USD',
+        },
+      ],
+    });
+
+    const output = formatJson([stack], FIXED_NOW);
+    const parsed = JSON.parse(output) as BreakdownResult;
+
+    const cr = parsed.stacks[0]!.conditionalResources[0]!;
+    expect(cr.logicalId).toBe('ConditionalEc2');
+    expect(cr.conditionName).toBe('IsProd');
+    expect(cr.monthlyCost).toBe(70.08);
+    expect(cr.note).toBe('Excluded from total — gated by CloudFormation Condition');
+  });
+
+  it('maps conditional usage-based resource with null monthlyCost', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const stack = makeStack({
+      pricedResources: [],
+      stackMonthlyCost: 0,
+      conditionalResources: [
+        {
+          logicalId: 'ConditionalLambda',
+          type: 'AWS::Lambda::Function',
+          conditionName: 'IsEnabled',
+          monthlyCost: null,
+          currency: 'USD',
+        },
+      ],
+    });
+
+    const output = formatJson([stack], FIXED_NOW);
+    const parsed = JSON.parse(output) as BreakdownResult;
+
+    expect(parsed.stacks[0]!.conditionalResources[0]!.monthlyCost).toBeNull();
+  });
+
+  it('sets summary counts correctly for mixed stack', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const stack = makeStack({
+      pricedResources: [
+        { logicalId: 'Ec2', type: 'AWS::EC2::Instance', monthlyCost: 70, currency: 'USD', basis: 'Hrs' },
+      ],
+      usageBasedResources: [
+        { logicalId: 'Lambda', type: 'AWS::Lambda::Function', unitPrice: 0.0000002, unit: 'Requests', currency: 'USD' },
+      ],
+      conditionalResources: [
+        { logicalId: 'CondEc2', type: 'AWS::EC2::Instance', conditionName: 'IsProd', monthlyCost: 70, currency: 'USD' },
+      ],
+      unsupportedTypes: ['AWS::CloudFront::Distribution'],
+      stackMonthlyCost: 70,
+    });
+
+    const output = formatJson([stack], FIXED_NOW);
+    const parsed = JSON.parse(output) as BreakdownResult;
+    const summary = parsed.summary;
+
+    expect(summary.totalStacks).toBe(1);
+    expect(summary.pricedResources).toBe(1);
+    expect(summary.usageBasedResources).toBe(1);
+    expect(summary.conditionalResources).toBe(1);
+    expect(summary.unsupportedResources).toBe(1);
+    expect(summary.totalResources).toBe(3); // priced + usage-based + conditional
+  });
+
+  it('passes through stackId, region, regionSource, and unsupportedTypes', async () => {
+    const { formatJson } = await import('../../../src/output/json.js');
+    const stack = makeStack({
+      stackId: 'ProdStack',
+      region: 'eu-west-1',
+      regionSource: 'flag',
+      unsupportedTypes: ['AWS::CloudFront::Distribution'],
+    });
+
+    const output = formatJson([stack], FIXED_NOW);
+    const parsed = JSON.parse(output) as BreakdownResult;
+    const sr = parsed.stacks[0]!;
+
+    expect(sr.stackId).toBe('ProdStack');
+    expect(sr.region).toBe('eu-west-1');
+    expect(sr.regionSource).toBe('flag');
+    expect(sr.unsupportedTypes).toContain('AWS::CloudFront::Distribution');
+  });
+});

--- a/tests/unit/output/summary.test.ts
+++ b/tests/unit/output/summary.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { PricedStack } from '../../../src/pricing/types.js';
+import { formatSummary } from '../../../src/output/summary.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeStack(overrides: Partial<PricedStack> = {}): PricedStack {
+  return {
+    stackId: 'MyStack',
+    region: 'us-east-1',
+    regionSource: 'template',
+    pricedResources: [
+      {
+        logicalId: 'Ec2Instance',
+        type: 'AWS::EC2::Instance',
+        monthlyCost: 70.08,
+        currency: 'USD',
+        basis: 'Hrs',
+      },
+    ],
+    usageBasedResources: [],
+    conditionalResources: [],
+    unsupportedTypes: [],
+    stackMonthlyCost: 70.08,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('formatSummary', () => {
+  const FIXED_NOW = new Date('2025-06-01T12:00:00.000Z').getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(FIXED_NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('produces expected format with priced resources', () => {
+    const stacks = [makeStack()];
+    const result = formatSummary(stacks, FIXED_NOW - 1200);
+
+    expect(result).toBe('TOTAL: $70.08/month · 1 stack · 1 priced · 1.2s');
+  });
+
+  it('includes usage-based count when present', () => {
+    const stack = makeStack({
+      usageBasedResources: [
+        { logicalId: 'Lambda', type: 'AWS::Lambda::Function', unitPrice: 0.0000002, unit: 'Requests', currency: 'USD' },
+      ],
+    });
+    const result = formatSummary([stack], FIXED_NOW - 500);
+
+    expect(result).toContain('+ usage-based');
+    expect(result).toContain('1 usage-based');
+  });
+
+  it('shows N/A for cost when only usage-based resources present', () => {
+    const stack = makeStack({
+      pricedResources: [],
+      stackMonthlyCost: 0,
+      usageBasedResources: [
+        { logicalId: 'Lambda', type: 'AWS::Lambda::Function', unitPrice: 0.0000002, unit: 'Requests', currency: 'USD' },
+      ],
+    });
+    const result = formatSummary([stack], FIXED_NOW - 800);
+
+    expect(result).toContain('TOTAL: N/A');
+    expect(result).toContain('+ usage-based');
+  });
+
+  it('handles empty stacks array gracefully', () => {
+    const result = formatSummary([], FIXED_NOW - 300);
+
+    expect(result).toContain('TOTAL: $0.00/month');
+    expect(result).toContain('0 stacks');
+    expect(result).toContain('0 priced');
+  });
+
+  it('sums costs across multiple stacks', () => {
+    const stack1 = makeStack({ stackId: 'Stack1', stackMonthlyCost: 50.00, pricedResources: [
+      { logicalId: 'Ec2A', type: 'AWS::EC2::Instance', monthlyCost: 50.00, currency: 'USD', basis: 'Hrs' },
+    ]});
+    const stack2 = makeStack({ stackId: 'Stack2', stackMonthlyCost: 122.65, pricedResources: [
+      { logicalId: 'Ec2B', type: 'AWS::EC2::Instance', monthlyCost: 122.65, currency: 'USD', basis: 'Hrs' },
+    ]});
+    const result = formatSummary([stack1, stack2], FIXED_NOW - 1200);
+
+    expect(result).toContain('$172.65/month');
+    expect(result).toContain('2 stacks');
+    expect(result).toContain('2 priced');
+  });
+
+  it('uses plural for stacks when count > 1', () => {
+    const stack1 = makeStack({ stackId: 'Stack1' });
+    const stack2 = makeStack({ stackId: 'Stack2' });
+    const result = formatSummary([stack1, stack2], FIXED_NOW);
+
+    expect(result).toContain('2 stacks');
+  });
+
+  it('uses singular for stack when count is 1', () => {
+    const result = formatSummary([makeStack()], FIXED_NOW);
+
+    expect(result).toContain('1 stack ');
+    expect(result).not.toContain('1 stacks');
+  });
+
+  it('formats elapsed time correctly', () => {
+    const result = formatSummary([makeStack()], FIXED_NOW - 2500);
+
+    expect(result).toContain('2.5s');
+  });
+
+  it('does not show usage-based segment when no usage-based resources', () => {
+    const result = formatSummary([makeStack()], FIXED_NOW - 800);
+
+    expect(result).not.toContain('usage-based');
+  });
+});

--- a/tests/unit/output/table.test.ts
+++ b/tests/unit/output/table.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from 'vitest';
+import type { PricedStack } from '../../../src/pricing/types.js';
+import { formatTable } from '../../../src/output/table.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeStack(overrides: Partial<PricedStack> = {}): PricedStack {
+  return {
+    stackId: 'MyStack',
+    region: 'us-east-1',
+    regionSource: 'template',
+    pricedResources: [
+      {
+        logicalId: 'Ec2Instance',
+        type: 'AWS::EC2::Instance',
+        monthlyCost: 70.08,
+        currency: 'USD',
+        basis: 'Hrs',
+      },
+      {
+        logicalId: 'RdsDb',
+        type: 'AWS::RDS::DBInstance',
+        monthlyCost: 102.57,
+        currency: 'USD',
+        basis: 'Hrs',
+      },
+    ],
+    usageBasedResources: [],
+    conditionalResources: [],
+    unsupportedTypes: [],
+    stackMonthlyCost: 172.65,
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('formatTable', () => {
+  describe('structure', () => {
+    it('includes stack header with stackId and region', () => {
+      const result = formatTable([makeStack()], true);
+      expect(result).toContain('Stack: MyStack');
+      expect(result).toContain('Region: us-east-1');
+    });
+
+    it('includes resource logicalIds in the table', () => {
+      const result = formatTable([makeStack()], true);
+      expect(result).toContain('Ec2Instance');
+      expect(result).toContain('RdsDb');
+    });
+
+    it('includes resource types in the table', () => {
+      const result = formatTable([makeStack()], true);
+      expect(result).toContain('AWS::EC2::Instance');
+      expect(result).toContain('AWS::RDS::DBInstance');
+    });
+
+    it('includes monthly costs formatted as $x.xx', () => {
+      const result = formatTable([makeStack()], true);
+      expect(result).toContain('$70.08');
+      expect(result).toContain('$102.57');
+    });
+
+    it('includes stack subtotal row', () => {
+      const result = formatTable([makeStack()], true);
+      expect(result).toContain('Stack Subtotal');
+      expect(result).toContain('$172.65');
+    });
+
+    it('includes TOTAL ESTIMATED MONTHLY COST footer', () => {
+      const result = formatTable([makeStack()], true);
+      expect(result).toContain('TOTAL ESTIMATED MONTHLY COST: $172.65');
+    });
+
+    it('sorts fixed resources descending by monthlyCost', () => {
+      const result = formatTable([makeStack()], true);
+      const ec2Pos = result.indexOf('Ec2Instance');
+      const rdsPos = result.indexOf('RdsDb');
+      // RDS ($102.57) should appear before EC2 ($70.08) after descending sort
+      expect(rdsPos).toBeLessThan(ec2Pos);
+    });
+  });
+
+  describe('usage-based resources', () => {
+    it('renders usage-based table when present', () => {
+      const stack = makeStack({
+        usageBasedResources: [
+          { logicalId: 'MyLambda', type: 'AWS::Lambda::Function', unitPrice: 0.0000002, unit: 'Requests', currency: 'USD' },
+        ],
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('MyLambda');
+      expect(result).toContain('AWS::Lambda::Function');
+      expect(result).toContain('Usage-based — provide estimate via --usage-file');
+    });
+
+    it('appends + usage-based to TOTAL line when usage-based resources exist', () => {
+      const stack = makeStack({
+        usageBasedResources: [
+          { logicalId: 'MyLambda', type: 'AWS::Lambda::Function', unitPrice: 0.0000002, unit: 'Requests', currency: 'USD' },
+        ],
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('+ usage-based');
+    });
+
+    it('does not show + usage-based when no usage-based resources', () => {
+      const result = formatTable([makeStack()], true);
+      expect(result).not.toContain('+ usage-based');
+    });
+  });
+
+  describe('conditional resources (ADR-011)', () => {
+    it('renders conditional resources table when present', () => {
+      const stack = makeStack({
+        conditionalResources: [
+          {
+            logicalId: 'ConditionalEc2',
+            type: 'AWS::EC2::Instance',
+            conditionName: 'IsProd',
+            monthlyCost: 70.08,
+            currency: 'USD',
+          },
+        ],
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('ConditionalEc2');
+      expect(result).toContain('IsProd');
+      expect(result).toContain('$70.08');
+    });
+
+    it('shows Usage-based for null monthlyCost conditional resources', () => {
+      const stack = makeStack({
+        conditionalResources: [
+          {
+            logicalId: 'ConditionalLambda',
+            type: 'AWS::Lambda::Function',
+            conditionName: 'IsEnabled',
+            monthlyCost: null,
+            currency: 'USD',
+          },
+        ],
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('ConditionalLambda');
+      expect(result).toContain('IsEnabled');
+      expect(result).toContain('Usage-based');
+    });
+  });
+
+  describe('empty stacks', () => {
+    it('handles empty stacks array gracefully', () => {
+      const result = formatTable([], true);
+      expect(result).toContain('TOTAL ESTIMATED MONTHLY COST: $0.00');
+    });
+
+    it('handles stack with no resources', () => {
+      const stack = makeStack({ pricedResources: [], stackMonthlyCost: 0 });
+      const result = formatTable([stack], true);
+      expect(result).toContain('Stack: MyStack');
+      expect(result).toContain('TOTAL ESTIMATED MONTHLY COST: $0.00');
+    });
+  });
+
+  describe('unsupported types', () => {
+    it('lists unsupported types', () => {
+      const stack = makeStack({ unsupportedTypes: ['AWS::CloudFront::Distribution'] });
+      const result = formatTable([stack], true);
+      expect(result).toContain('AWS::CloudFront::Distribution');
+    });
+  });
+
+  describe('noColor', () => {
+    it('noColor=true produces output without ANSI escape codes', () => {
+      const result = formatTable([makeStack()], true);
+      // ANSI escape sequences start with ESC (\x1b) followed by [
+      expect(result).not.toMatch(/\x1b\[/);
+    });
+
+    it('noColor=false produces output with ANSI escape codes for headers', () => {
+      const result = formatTable([makeStack()], false);
+      expect(result).toMatch(/\x1b\[/);
+    });
+
+    it('both noColor modes produce the same resource data', () => {
+      const stack = makeStack();
+      const withColor = formatTable([stack], false);
+      const noColor = formatTable([stack], true);
+
+      // Strip ANSI from colored output
+      const stripped = withColor.replace(/\x1b\[[0-9;]*m/g, '');
+      // Both should contain the same logical content
+      expect(stripped).toContain('Ec2Instance');
+      expect(noColor).toContain('Ec2Instance');
+    });
+  });
+
+  describe('noColor=false branches for sub-tables', () => {
+    it('renders usage-based table with color enabled', () => {
+      const stack = makeStack({
+        usageBasedResources: [
+          { logicalId: 'MyLambda', type: 'AWS::Lambda::Function', unitPrice: 0.0000002, unit: 'Requests', currency: 'USD' },
+        ],
+      });
+      const result = formatTable([stack], false);
+      expect(result).toContain('MyLambda');
+      // With color enabled, ANSI codes should be present
+      expect(result).toMatch(/\x1b\[/);
+    });
+
+    it('renders conditional table with color enabled', () => {
+      const stack = makeStack({
+        conditionalResources: [
+          {
+            logicalId: 'CondEc2',
+            type: 'AWS::EC2::Instance',
+            conditionName: 'IsProd',
+            monthlyCost: 70.08,
+            currency: 'USD',
+          },
+        ],
+      });
+      const result = formatTable([stack], false);
+      expect(result).toContain('CondEc2');
+      expect(result).toMatch(/\x1b\[/);
+    });
+
+    it('renders unsupported types label with color enabled', () => {
+      const stack = makeStack({ unsupportedTypes: ['AWS::CloudFront::Distribution'] });
+      const result = formatTable([stack], false);
+      expect(result).toContain('AWS::CloudFront::Distribution');
+      expect(result).toMatch(/\x1b\[/);
+    });
+  });
+
+  describe('multi-stack', () => {
+    it('renders headers for each stack', () => {
+      const stack1 = makeStack({ stackId: 'StackA', region: 'us-east-1' });
+      const stack2 = makeStack({ stackId: 'StackB', region: 'eu-west-1' });
+      const result = formatTable([stack1, stack2], true);
+
+      expect(result).toContain('Stack: StackA');
+      expect(result).toContain('Stack: StackB');
+      expect(result).toContain('Region: us-east-1');
+      expect(result).toContain('Region: eu-west-1');
+    });
+
+    it('sums costs from all stacks in the TOTAL line', () => {
+      const stack1 = makeStack({ stackId: 'Stack1', stackMonthlyCost: 50.00, pricedResources: [
+        { logicalId: 'Ec2A', type: 'AWS::EC2::Instance', monthlyCost: 50.00, currency: 'USD', basis: 'Hrs' },
+      ]});
+      const stack2 = makeStack({ stackId: 'Stack2', stackMonthlyCost: 122.65, pricedResources: [
+        { logicalId: 'Ec2B', type: 'AWS::EC2::Instance', monthlyCost: 122.65, currency: 'USD', basis: 'Hrs' },
+      ]});
+      const result = formatTable([stack1, stack2], true);
+
+      expect(result).toContain('TOTAL ESTIMATED MONTHLY COST: $172.65');
+    });
+  });
+});


### PR DESCRIPTION
Add src/output/ module (Stage 5 of the pipeline): types.ts defines the stable v1.0 JSON schema; json.ts serialises PricedStack[] to BreakdownResult; summary.ts produces a single-line cost summary; table.ts renders per-stack cli-table3 tables with chalk colour support and noColor flag.

Install chalk@4 and cli-table3 as production dependencies. 440 tests passing, output/ at 100% statement/branch coverage.