### PR TITLE
feat: wire diff command into CLI

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -10,6 +10,8 @@ import { priceStacks } from '../pricing/engine.js';
 import { formatTable } from '../output/table.js';
 import { formatJson } from '../output/json.js';
 import { formatSummary } from '../output/summary.js';
+import { computeDiff, formatDiffTable, formatDiffJson, formatDiffSummary } from '../output/diff.js';
+import type { BreakdownResult } from '../output/types.js';
 import { ResourceHandlerRegistry } from '../registry/index.js';
 import { ec2Handler } from '../registry/handlers/ec2.js';
 import { rdsHandler } from '../registry/handlers/rds.js';
@@ -22,7 +24,13 @@ import { snsHandler } from '../registry/handlers/sns.js';
 import { StackPriceError } from '../errors/index.js';
 import packageJson from '../../package.json';
 
-// ─── Commander option shape (before mapping to CliOptions) ───────────────────
+// ─── Commander option shapes ──────────────────────────────────────────────────
+
+interface DiffOptions {
+  format: string;
+  color: boolean;   // false when --no-color is passed
+  outFile?: string;
+}
 
 interface BreakdownOptions {
   dir: string;
@@ -34,6 +42,19 @@ interface BreakdownOptions {
   color: boolean;   // false when --no-color is passed
   verbose: boolean;
   cache: boolean;   // false when --no-cache is passed
+}
+
+// ─── Type guards ─────────────────────────────────────────────────────────────
+
+function isBreakdownResult(value: unknown): value is BreakdownResult {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'schemaVersion' in value &&
+    (value as Record<string, unknown>).schemaVersion === '1.0' &&
+    'stacks' in value &&
+    Array.isArray((value as Record<string, unknown>).stacks)
+  );
 }
 
 // ─── Registry factory ─────────────────────────────────────────────────────────
@@ -159,14 +180,97 @@ export function createProgram(): Command {
       }
     });
 
-  // ── diff (coming soon) ─────────────────────────────────────────────────────
+  // ── diff ───────────────────────────────────────────────────────────────────
 
   program
     .command('diff')
-    .description('Compare costs between two CDK assemblies (coming in v0.2.0)')
-    .action(() => {
-      process.stdout.write('stackprice diff is coming in v0.2.0\n');
-      process.exit(0);
+    .description('Compare costs between two stackprice JSON output files')
+    .argument('<before>', 'Path to the first breakdown JSON file')
+    .argument('<after>', 'Path to the second breakdown JSON file')
+    .option('--format <format>', 'Output format: table | json | summary', 'table')
+    .option('--no-color', 'Disable colour output')
+    .option('--out-file <path>', 'Write output to file instead of stdout (optional)')
+    .action((beforeArg: string, afterArg: string, options: DiffOptions) => {
+      const noColor = !options.color;
+
+      try {
+        // ── 1. Validate paths (Security Rule 1 — path validation) ────────────
+        const resolvedBefore = path.resolve(beforeArg);
+        if (!fs.existsSync(resolvedBefore)) {
+          throw new StackPriceError(
+            `File not found: ${beforeArg}. Generate one with: stackprice breakdown --output json --out-file <path>`,
+            2,
+          );
+        }
+
+        const resolvedAfter = path.resolve(afterArg);
+        if (!fs.existsSync(resolvedAfter)) {
+          throw new StackPriceError(
+            `File not found: ${afterArg}. Generate one with: stackprice breakdown --output json --out-file <path>`,
+            2,
+          );
+        }
+
+        // ── 2. Read and parse both files ──────────────────────────────────────
+        let beforeData: unknown;
+        try {
+          beforeData = JSON.parse(fs.readFileSync(resolvedBefore, 'utf-8') as string);
+        } catch {
+          throw new StackPriceError(`${beforeArg} is not a valid JSON file`, 2);
+        }
+
+        let afterData: unknown;
+        try {
+          afterData = JSON.parse(fs.readFileSync(resolvedAfter, 'utf-8') as string);
+        } catch {
+          throw new StackPriceError(`${afterArg} is not a valid JSON file`, 2);
+        }
+
+        // ── 3. Type-guard: verify schema ──────────────────────────────────────
+        if (!isBreakdownResult(beforeData)) {
+          throw new StackPriceError(
+            `${beforeArg} is not a valid stackprice output file. Generate one with: stackprice breakdown --output json --out-file <path>`,
+            2,
+          );
+        }
+
+        if (!isBreakdownResult(afterData)) {
+          throw new StackPriceError(
+            `${afterArg} is not a valid stackprice output file. Generate one with: stackprice breakdown --output json --out-file <path>`,
+            2,
+          );
+        }
+
+        // ── 4. Compute diff ───────────────────────────────────────────────────
+        const diff = computeDiff(beforeData, afterData, resolvedBefore, resolvedAfter);
+
+        // ── 5. Format output ──────────────────────────────────────────────────
+        const format = options.format as 'table' | 'json' | 'summary';
+        let formatted: string;
+        if (format === 'json') {
+          formatted = formatDiffJson(diff);
+        } else if (format === 'summary') {
+          formatted = formatDiffSummary(diff);
+        } else {
+          formatted = formatDiffTable(diff, noColor);
+        }
+
+        // ── 6. Write output ───────────────────────────────────────────────────
+        if (options.outFile !== undefined) {
+          const resolvedOutFile = path.resolve(options.outFile);
+          fs.writeFileSync(resolvedOutFile, formatted + '\n', 'utf-8');
+        } else {
+          process.stdout.write(formatted + '\n');
+        }
+      } catch (err: unknown) {
+        if (err instanceof StackPriceError) {
+          process.stderr.write(`Error: ${err.message}\n`);
+          process.exit(err.exitCode);
+        } else {
+          process.stderr.write(`An unexpected error occurred. Use --verbose for details.\n`);
+          process.exit(2);
+        }
+      }
     });
 
   return program;

--- a/tests/unit/cli/parser.test.ts
+++ b/tests/unit/cli/parser.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { ParsedStack } from '../../../src/template/types.js';
 import type { PricedStack } from '../../../src/pricing/types.js';
+import type { BreakdownResult } from '../../../src/output/types.js';
+import type { DiffResult } from '../../../src/output/diff-types.js';
 
 // ─── fs mocks ─────────────────────────────────────────────────────────────────
 
 const mockExistsSync = vi.fn();
 const mockWriteFileSync = vi.fn();
+const mockReadFileSync = vi.fn();
 
 vi.mock('fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('fs')>();
@@ -13,6 +16,7 @@ vi.mock('fs', async (importOriginal) => {
     ...actual,
     existsSync: (...args: unknown[]): unknown => mockExistsSync(...args),
     writeFileSync: (...args: unknown[]): unknown => mockWriteFileSync(...args),
+    readFileSync: (...args: unknown[]): unknown => mockReadFileSync(...args),
   };
 });
 
@@ -60,6 +64,18 @@ vi.mock('../../../src/output/summary.js', () => ({
   formatSummary: (...args: unknown[]): unknown => mockFormatSummary(...args),
 }));
 
+const mockComputeDiff = vi.fn();
+const mockFormatDiffTable = vi.fn();
+const mockFormatDiffJson = vi.fn();
+const mockFormatDiffSummary = vi.fn();
+
+vi.mock('../../../src/output/diff.js', () => ({
+  computeDiff: (...args: unknown[]): unknown => mockComputeDiff(...args),
+  formatDiffTable: (...args: unknown[]): unknown => mockFormatDiffTable(...args),
+  formatDiffJson: (...args: unknown[]): unknown => mockFormatDiffJson(...args),
+  formatDiffSummary: (...args: unknown[]): unknown => mockFormatDiffSummary(...args),
+}));
+
 import { createProgram } from '../../../src/cli/parser.js';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -74,6 +90,47 @@ function makeParsedStack(stackId: string): ParsedStack {
     resources: [],
     conditionalResources: [],
     unsupportedTypes: [],
+  };
+}
+
+function makeBreakdownResult(): BreakdownResult {
+  return {
+    schemaVersion: '1.0',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    stackpriceVersion: '0.1.0',
+    stacks: [],
+    totalMonthlyCost: 0,
+    currency: 'USD',
+    summary: {
+      totalStacks: 0,
+      totalResources: 0,
+      pricedResources: 0,
+      usageBasedResources: 0,
+      conditionalResources: 0,
+      unsupportedResources: 0,
+      executionTimeMs: 0,
+    },
+  };
+}
+
+function makeDiffResult(): DiffResult {
+  return {
+    schemaVersion: '1.0',
+    timestamp: '2026-01-01T00:00:00.000Z',
+    beforeFile: '/fake/before.json',
+    afterFile: '/fake/after.json',
+    resources: [],
+    usageBasedResources: [],
+    summary: {
+      added: 0,
+      removed: 0,
+      changed: 0,
+      unchanged: 0,
+      beforeTotal: 0,
+      afterTotal: 0,
+      delta: 0,
+      deltaPercent: null,
+    },
   };
 }
 
@@ -100,7 +157,7 @@ describe('createProgram — breakdown command', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExistsSync.mockReturnValue(true);
-    mockExit = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never);
+    mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
     mockStdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
     mockStderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
@@ -324,22 +381,170 @@ describe('createProgram — breakdown command', () => {
 describe('createProgram — diff command', () => {
   let mockExit: ReturnType<typeof vi.spyOn>;
   let mockStdout: ReturnType<typeof vi.spyOn>;
+  let mockStderr: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockExit = vi.spyOn(process, 'exit').mockImplementation((_code?: number) => undefined as never);
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(JSON.stringify(makeBreakdownResult()));
+    mockComputeDiff.mockReturnValue(makeDiffResult());
+    mockFormatDiffTable.mockReturnValue('diff table output');
+    mockFormatDiffJson.mockReturnValue('{"diff":true}');
+    mockFormatDiffSummary.mockReturnValue('+$0.00/month · 0 added · 0 removed');
+    mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
     mockStdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    mockStderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('prints coming-soon message and exits 0', async () => {
+  it('valid before + after files → calls computeDiff + formatDiffTable + writes to stdout', async () => {
     const program = createProgram();
-    await program.parseAsync(['node', 'stackprice', 'diff']);
+    await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
 
-    expect(mockStdout).toHaveBeenCalledWith('stackprice diff is coming in v0.2.0\n');
-    expect(mockExit).toHaveBeenCalledWith(0);
+    expect(mockComputeDiff).toHaveBeenCalledOnce();
+    expect(mockFormatDiffTable).toHaveBeenCalledOnce();
+    expect(mockFormatDiffJson).not.toHaveBeenCalled();
+    expect(mockFormatDiffSummary).not.toHaveBeenCalled();
+    expect(mockStdout).toHaveBeenCalledWith('diff table output\n');
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('before file not found → StackPriceError with path and hint', async () => {
+    mockExistsSync.mockImplementation((p: unknown) =>
+      typeof p === 'string' && !p.includes('before'),
+    );
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('File not found'));
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('before.json'));
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(mockComputeDiff).not.toHaveBeenCalled();
+  });
+
+  it('after file not found → StackPriceError with path and hint', async () => {
+    mockExistsSync.mockImplementation((p: unknown) =>
+      typeof p === 'string' && !p.includes('after'),
+    );
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('File not found'));
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('after.json'));
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(mockComputeDiff).not.toHaveBeenCalled();
+  });
+
+  it('invalid JSON in before file → StackPriceError "not a valid JSON file"', async () => {
+    mockReadFileSync.mockReturnValueOnce('not json at all');
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('not a valid JSON file'));
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it('invalid JSON in after file → StackPriceError "not a valid JSON file"', async () => {
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify(makeBreakdownResult()))
+      .mockReturnValueOnce('{bad json');
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('not a valid JSON file'));
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it('wrong schema (missing schemaVersion) in before file → StackPriceError', async () => {
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify({ stacks: [] }));
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
+
+    expect(mockStderr).toHaveBeenCalledWith(
+      expect.stringContaining('not a valid stackprice output file'),
+    );
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it('wrong schema in after file → StackPriceError', async () => {
+    mockReadFileSync
+      .mockReturnValueOnce(JSON.stringify(makeBreakdownResult()))
+      .mockReturnValueOnce(JSON.stringify({ stacks: [] }));
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
+
+    expect(mockStderr).toHaveBeenCalledWith(
+      expect.stringContaining('not a valid stackprice output file'),
+    );
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it('--format json → formatDiffJson called, formatDiffTable not called', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'diff',
+      '/fake/before.json', '/fake/after.json',
+      '--format', 'json',
+    ]);
+
+    expect(mockFormatDiffJson).toHaveBeenCalledOnce();
+    expect(mockFormatDiffTable).not.toHaveBeenCalled();
+    expect(mockStdout).toHaveBeenCalledWith('{"diff":true}\n');
+  });
+
+  it('--format summary → formatDiffSummary called, formatDiffTable not called', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'diff',
+      '/fake/before.json', '/fake/after.json',
+      '--format', 'summary',
+    ]);
+
+    expect(mockFormatDiffSummary).toHaveBeenCalledOnce();
+    expect(mockFormatDiffTable).not.toHaveBeenCalled();
+    expect(mockStdout).toHaveBeenCalledWith('+$0.00/month · 0 added · 0 removed\n');
+  });
+
+  it('--out-file writes to file instead of stdout', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'diff',
+      '/fake/before.json', '/fake/after.json',
+      '--out-file', '/tmp/diff-output.txt',
+    ]);
+
+    expect(mockWriteFileSync).toHaveBeenCalledWith(
+      expect.stringContaining('diff-output.txt'),
+      'diff table output\n',
+      'utf-8',
+    );
+    expect(mockStdout).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call checkCredentials', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
+
+    expect(mockCheckCredentials).not.toHaveBeenCalled();
+  });
+
+  it('--no-color passes noColor=true to formatDiffTable', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'diff',
+      '/fake/before.json', '/fake/after.json',
+      '--no-color',
+    ]);
+
+    expect(mockFormatDiffTable).toHaveBeenCalledWith(expect.any(Object), true);
   });
 });


### PR DESCRIPTION
Replace the coming-soon stub with the real diff implementation: reads and validates two breakdown JSON files, calls computeDiff, and formats output via table/json/summary. Tests cover all error paths (file not found, invalid JSON, wrong schema) and confirm checkCredentials is never called.