### PR TITLE
fix: ElastiCache filter field instanceType not cacheNodeType

### DIFF
--- a/src/registry/handlers/elasticache.ts
+++ b/src/registry/handlers/elasticache.ts
@@ -4,7 +4,7 @@ import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handle
 import { REGION_TO_LOCATION } from '../handler.js';
 
 interface ElastiCacheAttributes extends PricingAttributes {
-  cacheNodeType: string;
+  instanceType: string;
   cacheEngine: string;
   numCacheNodes: number;
 }
@@ -37,7 +37,7 @@ export const elasticacheHandler: ResourceHandler = {
     const numCacheNodesRaw = properties['NumCacheNodes'];
     const numCacheNodes = typeof numCacheNodesRaw === 'number' ? numCacheNodesRaw : 1;
 
-    return { cacheNodeType, cacheEngine, numCacheNodes } satisfies ElastiCacheAttributes;
+    return { instanceType: cacheNodeType, cacheEngine, numCacheNodes } satisfies ElastiCacheAttributes;
   },
 
   buildPricingQuery(attributes: PricingAttributes, region: string): PricingQuery {
@@ -47,7 +47,7 @@ export const elasticacheHandler: ResourceHandler = {
     return {
       serviceCode: 'AmazonElastiCache',
       filters: [
-        { field: 'cacheNodeType', value: attrs.cacheNodeType },
+        { field: 'instanceType', value: attrs.instanceType },
         { field: 'cacheEngine', value: attrs.cacheEngine },
         { field: 'location', value: location },
       ],

--- a/tests/unit/registry/handlers/elasticache.test.ts
+++ b/tests/unit/registry/handlers/elasticache.test.ts
@@ -96,11 +96,11 @@ describe('elasticacheHandler', () => {
       expect(attrs!['numCacheNodes']).toBe(5);
     });
 
-    it('preserves cacheNodeType from CacheNodeType', () => {
+    it('preserves instanceType from CacheNodeType', () => {
       const attrs = elasticacheHandler.extractPricingAttributes(
         makeResource({ CacheNodeType: 'cache.r6g.xlarge', Engine: 'redis' }),
       );
-      expect(attrs!['cacheNodeType']).toBe('cache.r6g.xlarge');
+      expect(attrs!['instanceType']).toBe('cache.r6g.xlarge');
     });
   });
 
@@ -116,13 +116,13 @@ describe('elasticacheHandler', () => {
       );
     });
 
-    it('sets cacheNodeType filter to CacheNodeType value', () => {
+    it('sets instanceType filter to CacheNodeType value', () => {
       const attrs = elasticacheHandler.extractPricingAttributes(
         makeResource({ CacheNodeType: 'cache.m6g.large', Engine: 'redis' }),
       )!;
       const query = elasticacheHandler.buildPricingQuery(attrs, 'us-east-1');
       const fields = Object.fromEntries(query.filters.map((f) => [f.field, f.value]));
-      expect(fields['cacheNodeType']).toBe('cache.m6g.large');
+      expect(fields['instanceType']).toBe('cache.m6g.large');
     });
 
     it('sets cacheEngine filter to mapped engine value', () => {


### PR DESCRIPTION
The AWS Pricing API for AmazonElastiCache uses "instanceType" as the filter field name, not "cacheNodeType". Update extractPricingAttributes to store the attribute under the key "instanceType", and update buildPricingQuery to send field: "instanceType" in the filter.