### PR TITLE
fix: correct API Gateway filter to productFamily=API Calls

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -22,6 +22,7 @@ import { ecsHandler } from '../registry/handlers/ecs.js';
 import { sqsHandler } from '../registry/handlers/sqs.js';
 import { snsHandler } from '../registry/handlers/sns.js';
 import { elasticacheHandler } from '../registry/handlers/elasticache.js';
+import { apigatewayHandler } from '../registry/handlers/apigateway.js';
 import { StackPriceError } from '../errors/index.js';
 import packageJson from '../../package.json';
 
@@ -71,6 +72,7 @@ function createRegistry(): ResourceHandlerRegistry {
   registry.register(sqsHandler);
   registry.register(snsHandler);
   registry.register(elasticacheHandler);
+  registry.register(apigatewayHandler);
   return registry;
 }
 

--- a/src/registry/handlers/apigateway.ts
+++ b/src/registry/handlers/apigateway.ts
@@ -3,13 +3,6 @@ import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
 import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
 import { REGION_TO_LOCATION } from '../handler.js';
 
-// NOTE: This handler is intentionally not registered in the CLI.
-// The AWS Price List API does not expose REST API per-request
-// pricing via GetProducts. The handler logic is correct — only
-// the pricing data source needs to change.
-// See GitHub issue #38 for full analysis and planned fix
-// using AWS bulk pricing files in v0.3.0.
-
 interface ApiGatewayAttributes extends PricingAttributes {
   endpointType: 'REGIONAL' | 'EDGE' | 'PRIVATE';
 }
@@ -46,7 +39,7 @@ export const apigatewayHandler: ResourceHandler = {
     return {
       serviceCode: 'AmazonApiGateway',
       filters: [
-        { field: 'group', value: 'Amazon API Gateway - Requests' },
+        { field: 'productFamily', value: 'API Calls' },
         { field: 'location', value: location },
       ],
     };

--- a/tests/unit/registry/handlers/apigateway.test.ts
+++ b/tests/unit/registry/handlers/apigateway.test.ts
@@ -105,11 +105,11 @@ describe('apigatewayHandler', () => {
       );
     });
 
-    it('sets group filter to "Amazon API Gateway - Requests"', () => {
+    it('sets productFamily filter to "API Calls"', () => {
       const attrs = apigatewayHandler.extractPricingAttributes(makeResource({}))!;
       const query = apigatewayHandler.buildPricingQuery(attrs, 'us-east-1');
       const fields = Object.fromEntries(query.filters.map((f) => [f.field, f.value]));
-      expect(fields['group']).toBe('Amazon API Gateway - Requests');
+      expect(fields['productFamily']).toBe('API Calls');
     });
 
     it('maps us-east-1 to US East (N. Virginia)', () => {
@@ -133,13 +133,14 @@ describe('apigatewayHandler', () => {
       expect(loc).toBe('xx-region-1');
     });
 
-    it('produces exactly two filters: group and location', () => {
+    it('produces exactly two filters: productFamily and location', () => {
       const attrs = apigatewayHandler.extractPricingAttributes(makeResource({}))!;
       const query = apigatewayHandler.buildPricingQuery(attrs, 'us-east-1');
       expect(query.filters).toHaveLength(2);
       const fieldNames = query.filters.map((f) => f.field);
-      expect(fieldNames).toContain('group');
+      expect(fieldNames).toContain('productFamily');
       expect(fieldNames).toContain('location');
+      expect(fieldNames).not.toContain('group');
     });
   });
 


### PR DESCRIPTION
The original handler used group="Amazon API Gateway - Requests" which does not exist in the AmazonApiGateway service. Verified correct filter is productFamily="API Calls" via live API query. Also re-registers the handler in the CLI (it was blocked in v0.2.0 pending this fix).