### PR TITLE
fix: prefer Tier 1 price in tiered pricing, pin API Gateway to REST A…

### DIFF
--- a/src/pricing/client.ts
+++ b/src/pricing/client.ts
@@ -55,6 +55,7 @@ function extractPriceFromItem(item: unknown): PricingApiResult | null {
     price: number;
     unit: string;
     currency: string;
+    beginRange?: string | number;
   }
   const candidates: ParsedDim[] = [];
 
@@ -65,6 +66,7 @@ function extractPriceFromItem(item: unknown): PricingApiResult | null {
     const dimObj = dim as Record<string, unknown>;
     const unit = dimObj['unit'];
     const pricePerUnitMap = dimObj['pricePerUnit'];
+    const beginRange = dimObj['beginRange'];
 
     if (typeof unit !== 'string') continue;
     if (typeof pricePerUnitMap !== 'object' || pricePerUnitMap === null) continue;
@@ -98,16 +100,26 @@ function extractPriceFromItem(item: unknown): PricingApiResult | null {
     }
 
     if (price !== undefined && currency !== undefined) {
-      candidates.push({ price, unit, currency });
+      const entry: ParsedDim = { price, unit, currency };
+      if (typeof beginRange === 'string' || typeof beginRange === 'number') {
+        entry.beginRange = beginRange;
+      }
+      candidates.push(entry);
     }
   }
 
   if (candidates.length === 0) return null;
 
-  // Return the first non-zero candidate; only fall back to zero if every
-  // dimension has pricePerUnit === 0 (e.g. genuinely free resources).
+  // For tiered pricing (e.g. API Gateway), prefer the Tier 1 dimension
+  // (beginRange === 0) which is the standard first-tier rate. Fall back to
+  // the first non-zero candidate for services with no beginRange field.
+  // Only fall back to zero if every dimension has pricePerUnit === 0
+  // (e.g. genuinely free resources).
+  const tier1 = candidates.find(
+    (c) => (c.beginRange === '0' || c.beginRange === 0) && c.price !== 0,
+  );
   const nonZero = candidates.find((c) => c.price !== 0);
-  const chosen = nonZero ?? candidates[0]!;
+  const chosen = tier1 ?? nonZero ?? candidates[0]!;
   return { pricePerUnit: chosen.price, unit: chosen.unit, currency: chosen.currency };
 }
 

--- a/src/registry/handlers/apigateway.ts
+++ b/src/registry/handlers/apigateway.ts
@@ -7,6 +7,41 @@ interface ApiGatewayAttributes extends PricingAttributes {
   endpointType: 'REGIONAL' | 'EDGE' | 'PRIVATE';
 }
 
+// Maps AWS region codes to the usagetype prefix used in API Gateway pricing.
+// Format: "{prefix}-ApiGatewayRequest"
+const REGION_TO_APIGW_PREFIX: Record<string, string> = {
+  'us-east-1': 'USE1',
+  'us-east-2': 'USE2',
+  'us-west-1': 'USW1',
+  'us-west-2': 'USW2',
+  'eu-west-1': 'EU',
+  'eu-west-2': 'EUW2',
+  'eu-west-3': 'EUW3',
+  'eu-central-1': 'EUC1',
+  'eu-central-2': 'EUC2',
+  'eu-north-1': 'EUN1',
+  'eu-south-1': 'EUS1',
+  'eu-south-2': 'EUS2',
+  'ap-southeast-1': 'APS1',
+  'ap-southeast-2': 'APS2',
+  'ap-southeast-3': 'APS3',
+  'ap-southeast-4': 'APS4',
+  'ap-northeast-1': 'APN1',
+  'ap-northeast-2': 'APN2',
+  'ap-northeast-3': 'APN3',
+  'ap-east-1': 'APE1',
+  'ap-east-2': 'APE2',
+  'ap-south-1': 'APS5',
+  'ca-central-1': 'CAN1',
+  'ca-west-1': 'CAN2',
+  'sa-east-1': 'SAE1',
+  'af-south-1': 'AFS1',
+  'me-south-1': 'MES1',
+  'me-central-1': 'MEC1',
+  'il-central-1': 'ILC1',
+  'mx-central-1': 'MXC1',
+};
+
 export const apigatewayHandler: ResourceHandler = {
   resourceType: 'AWS::ApiGateway::RestApi',
   isUsageBased: true,
@@ -35,14 +70,18 @@ export const apigatewayHandler: ResourceHandler = {
 
   buildPricingQuery(_attributes: PricingAttributes, region: string): PricingQuery {
     const location = REGION_TO_LOCATION[region] ?? region;
+    const prefix = REGION_TO_APIGW_PREFIX[region];
 
-    return {
-      serviceCode: 'AmazonApiGateway',
-      filters: [
-        { field: 'productFamily', value: 'API Calls' },
-        { field: 'location', value: location },
-      ],
-    };
+    const filters: PricingQuery['filters'] = [
+      { field: 'productFamily', value: 'API Calls' },
+      { field: 'location', value: location },
+    ];
+
+    if (prefix !== undefined) {
+      filters.push({ field: 'usagetype', value: `${prefix}-ApiGatewayRequest` });
+    }
+
+    return { serviceCode: 'AmazonApiGateway', filters };
   },
 
   calculateMonthlyCost(_result: PricingApiResult): MonthlyPrice | null {

--- a/tests/unit/pricing/client.test.ts
+++ b/tests/unit/pricing/client.test.ts
@@ -77,6 +77,73 @@ describe('fetchPrice', () => {
       expect(result!.pricePerUnit).toBe(0);
     });
 
+    it('prefers beginRange=0 dimension over other tiers in tiered pricing', async () => {
+      // API Gateway-style response: four tiers, beginRange=0 is the Tier 1 price.
+      const item = JSON.stringify({
+        terms: {
+          OnDemand: {
+            'OFFERTERM.RATE': {
+              priceDimensions: {
+                'OFFERTERM.RATE.TIER4': {
+                  unit: 'Requests',
+                  beginRange: '20000000000',
+                  pricePerUnit: { USD: '0.0000015100' },
+                },
+                'OFFERTERM.RATE.TIER2': {
+                  unit: 'Requests',
+                  beginRange: '333000000',
+                  pricePerUnit: { USD: '0.0000028000' },
+                },
+                'OFFERTERM.RATE.TIER1': {
+                  unit: 'Requests',
+                  beginRange: '0',
+                  pricePerUnit: { USD: '0.0000035000' },
+                },
+                'OFFERTERM.RATE.TIER3': {
+                  unit: 'Requests',
+                  beginRange: '1000000000',
+                  pricePerUnit: { USD: '0.0000023800' },
+                },
+              },
+            },
+          },
+        },
+      });
+      mockSend.mockResolvedValue({ PriceList: [item] });
+
+      const result = await fetchPrice(QUERY, REGION);
+
+      expect(result).not.toBeNull();
+      expect(result!.pricePerUnit).toBeCloseTo(0.0000035);
+      expect(result!.unit).toBe('Requests');
+      expect(result!.currency).toBe('USD');
+    });
+
+    it('falls back to first non-zero when no beginRange field is present', async () => {
+      // EC2-style response: single dimension with no beginRange.
+      const item = JSON.stringify({
+        terms: {
+          OnDemand: {
+            'OFFERTERM.RATE': {
+              priceDimensions: {
+                'OFFERTERM.RATE.DIM': {
+                  unit: 'Hrs',
+                  pricePerUnit: { USD: '0.0960' },
+                },
+              },
+            },
+          },
+        },
+      });
+      mockSend.mockResolvedValue({ PriceList: [item] });
+
+      const result = await fetchPrice(QUERY, REGION);
+
+      expect(result).not.toBeNull();
+      expect(result!.pricePerUnit).toBeCloseTo(0.096);
+      expect(result!.unit).toBe('Hrs');
+    });
+
     it('skips zero-price free-tier dimension and returns the non-zero paid-tier price', async () => {
       // DynamoDB-style response: first dimension is $0 free-tier, second is paid.
       const item = JSON.stringify({

--- a/tests/unit/registry/handlers/apigateway.test.ts
+++ b/tests/unit/registry/handlers/apigateway.test.ts
@@ -93,6 +93,13 @@ describe('apigatewayHandler', () => {
       );
       expect(attrs!['endpointType']).toBe('EDGE');
     });
+
+    it('defaults to EDGE when EndpointConfiguration is an array', () => {
+      const attrs = apigatewayHandler.extractPricingAttributes(
+        makeResource({ EndpointConfiguration: ['REGIONAL'] }),
+      );
+      expect(attrs!['endpointType']).toBe('EDGE');
+    });
   });
 
   // ─── buildPricingQuery ──────────────────────────────────────────────────────
@@ -133,14 +140,46 @@ describe('apigatewayHandler', () => {
       expect(loc).toBe('xx-region-1');
     });
 
-    it('produces exactly two filters: productFamily and location', () => {
+    it('produces three filters for a known region: productFamily, location, usagetype', () => {
       const attrs = apigatewayHandler.extractPricingAttributes(makeResource({}))!;
       const query = apigatewayHandler.buildPricingQuery(attrs, 'us-east-1');
+      expect(query.filters).toHaveLength(3);
+      const fieldNames = query.filters.map((f) => f.field);
+      expect(fieldNames).toContain('productFamily');
+      expect(fieldNames).toContain('location');
+      expect(fieldNames).toContain('usagetype');
+      expect(fieldNames).not.toContain('group');
+    });
+
+    it('sets usagetype filter to USE1-ApiGatewayRequest for us-east-1', () => {
+      const attrs = apigatewayHandler.extractPricingAttributes(makeResource({}))!;
+      const query = apigatewayHandler.buildPricingQuery(attrs, 'us-east-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('USE1-ApiGatewayRequest');
+    });
+
+    it('sets usagetype filter to EUC1-ApiGatewayRequest for eu-central-1', () => {
+      const attrs = apigatewayHandler.extractPricingAttributes(makeResource({}))!;
+      const query = apigatewayHandler.buildPricingQuery(attrs, 'eu-central-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('EUC1-ApiGatewayRequest');
+    });
+
+    it('sets usagetype filter to EU-ApiGatewayRequest for eu-west-1', () => {
+      const attrs = apigatewayHandler.extractPricingAttributes(makeResource({}))!;
+      const query = apigatewayHandler.buildPricingQuery(attrs, 'eu-west-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('EU-ApiGatewayRequest');
+    });
+
+    it('omits usagetype filter for unknown regions — graceful fallback', () => {
+      const attrs = apigatewayHandler.extractPricingAttributes(makeResource({}))!;
+      const query = apigatewayHandler.buildPricingQuery(attrs, 'xx-region-1');
       expect(query.filters).toHaveLength(2);
       const fieldNames = query.filters.map((f) => f.field);
       expect(fieldNames).toContain('productFamily');
       expect(fieldNames).toContain('location');
-      expect(fieldNames).not.toContain('group');
+      expect(fieldNames).not.toContain('usagetype');
     });
   });
 


### PR DESCRIPTION

- extractPriceFromItem in client.ts now selects the dimension with beginRange=0 when multiple tiers are present, ensuring the standard Tier 1 rate is returned instead of an arbitrary tier from unordered JSON object iteration
- buildPricingQuery in apigateway.ts adds a usagetype filter ({prefix}-ApiGatewayRequest) for known regions, pinning the query to REST API products and preventing HTTP API prices leaking into results
- Adds REGION_TO_APIGW_PREFIX map covering all current AWS regions
- Unknown regions omit the usagetype filter as a graceful fallback
- Tests: 2 new client.ts cases (tier preference, no-beginRange fallback); 4 new apigateway.ts cases (usagetype per region, unknown-region fallback, array EndpointConfiguration); updated filter-count assertion to 3