### PR TITLE
feat: implement --usage-file flag for usage-based cost estimates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,12 +14,14 @@
         "chalk": "^4.1.2",
         "cli-table3": "^0.6.5",
         "commander": "^14.0.3",
-        "env-paths": "^4.0.0"
+        "env-paths": "^4.0.0",
+        "js-yaml": "^4.1.1"
       },
       "bin": {
         "stackprice": "dist/index.js"
       },
       "devDependencies": {
+        "@types/js-yaml": "^4.0.9",
         "@types/node": "^25.5.0",
         "@typescript-eslint/eslint-plugin": "^8.57.2",
         "@typescript-eslint/parser": "^8.57.2",
@@ -2367,6 +2369,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2954,6 +2963,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -3707,6 +3722,18 @@
       "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "prepublishOnly": "npm run build && npm test"
   },
   "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
     "@types/node": "^25.5.0",
     "@typescript-eslint/eslint-plugin": "^8.57.2",
     "@typescript-eslint/parser": "^8.57.2",
@@ -65,6 +66,7 @@
     "chalk": "^4.1.2",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.3",
-    "env-paths": "^4.0.0"
+    "env-paths": "^4.0.0",
+    "js-yaml": "^4.1.1"
   }
 }

--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -7,6 +7,8 @@ import { checkCredentials } from '../pricing/credentials.js';
 import { readAssembly } from '../assembly/reader.js';
 import { parseStacks } from '../template/parser.js';
 import { priceStacks } from '../pricing/engine.js';
+import { parseUsageFile } from '../pricing/usage-calculator.js';
+import type { UsageFile } from '../pricing/types.js';
 import { formatTable } from '../output/table.js';
 import { formatJson } from '../output/json.js';
 import { formatSummary } from '../output/summary.js';
@@ -44,6 +46,7 @@ interface BreakdownOptions {
   color: boolean;   // false when --no-color is passed
   verbose: boolean;
   cache: boolean;   // false when --no-cache is passed
+  usageFile?: string;
 }
 
 // ─── Type guards ─────────────────────────────────────────────────────────────
@@ -99,6 +102,7 @@ export function createProgram(): Command {
     .option('--no-color', 'Disable colour output')
     .option('--verbose', 'Show region resolution details', false)
     .option('--no-cache', 'Skip cache, always fetch fresh prices')
+    .option('--usage-file <path>', 'Path to YAML usage estimates file (optional)')
     .action(async (options: BreakdownOptions) => {
       const startTime = Date.now();
 
@@ -153,8 +157,13 @@ export function createProgram(): Command {
         }
 
         // ── 6. Price stacks ───────────────────────────────────────────────────
+        let usageFileData: UsageFile | undefined;
+        if (options.usageFile !== undefined) {
+          usageFileData = parseUsageFile(options.usageFile);
+        }
+
         const registry = createRegistry();
-        const pricedStacks = await priceStacks(stacks, registry, noCache);
+        const pricedStacks = await priceStacks(stacks, registry, noCache, usageFileData);
 
         // ── 7. Format output ──────────────────────────────────────────────────
         let formatted: string;

--- a/src/output/json.ts
+++ b/src/output/json.ts
@@ -4,6 +4,7 @@ import type {
   PricedStackResult,
   ResourceResult,
   UsageBasedResult,
+  EstimatedResult,
   ConditionalResult,
   BreakdownSummary,
 } from './types.js';
@@ -24,6 +25,7 @@ function buildSummary(stacks: PricedStack[], executionTimeMs: number): Breakdown
     totalResources +=
       stack.pricedResources.length +
       stack.usageBasedResources.length +
+      stack.estimatedResources.length +
       stack.conditionalResources.length;
   }
 
@@ -56,6 +58,16 @@ function toStackResult(stack: PricedStack): PricedStackResult {
     note: 'Usage-based — provide estimate via --usage-file',
   }));
 
+  const estimatedResources: EstimatedResult[] = stack.estimatedResources.map((r) => ({
+    logicalId: r.logicalId,
+    type: r.type,
+    estimatedMonthlyCost: r.estimatedMonthlyCost,
+    currency: r.currency,
+    basis: r.basis,
+    unitPrice: r.unitPrice,
+    unit: r.unit,
+  }));
+
   const conditionalResources: ConditionalResult[] = stack.conditionalResources.map((r) => ({
     logicalId: r.logicalId,
     type: r.type,
@@ -71,6 +83,7 @@ function toStackResult(stack: PricedStack): PricedStackResult {
     regionSource: stack.regionSource,
     resources,
     usageBasedResources,
+    estimatedResources,
     conditionalResources,
     unsupportedTypes: stack.unsupportedTypes,
     stackMonthlyCost: stack.stackMonthlyCost,

--- a/src/output/summary.ts
+++ b/src/output/summary.ts
@@ -8,20 +8,40 @@ export function formatSummary(stacks: PricedStack[], startTime: number): string 
   const totalStacks = stacks.length;
   const pricedCount = stacks.reduce((sum, s) => sum + s.pricedResources.length, 0);
   const usageBasedCount = stacks.reduce((sum, s) => sum + s.usageBasedResources.length, 0);
+  const estimatedCount = stacks.reduce((sum, s) => sum + s.estimatedResources.length, 0);
+  const estimatedCost = stacks.reduce(
+    (sum, s) => sum + s.estimatedResources.reduce((s2, r) => s2 + r.estimatedMonthlyCost, 0),
+    0,
+  );
 
-  const onlyUsageBased = pricedCount === 0 && usageBasedCount > 0;
-  const costStr = onlyUsageBased ? 'N/A' : `$${totalMonthlyCost.toFixed(2)}/month`;
+  const fixedCost = totalMonthlyCost - estimatedCost;
+  const onlyUsageBased = pricedCount === 0 && estimatedCount === 0 && usageBasedCount > 0;
+
+  let costStr: string;
+  if (onlyUsageBased) {
+    costStr = 'N/A';
+  } else if (estimatedCount > 0 && usageBasedCount > 0) {
+    costStr = `$${fixedCost.toFixed(2)}/month + ~$${estimatedCost.toFixed(2)} estimated + usage-based`;
+  } else if (estimatedCount > 0) {
+    costStr = `$${fixedCost.toFixed(2)}/month + ~$${estimatedCost.toFixed(2)} estimated`;
+  } else {
+    costStr = `$${totalMonthlyCost.toFixed(2)}/month`;
+  }
 
   const parts: string[] = [
     `TOTAL: ${costStr}`,
   ];
 
-  if (usageBasedCount > 0) {
+  if (usageBasedCount > 0 && estimatedCount === 0) {
     parts[0] += ' + usage-based';
   }
 
   parts.push(`${totalStacks} stack${totalStacks !== 1 ? 's' : ''}`);
   parts.push(`${pricedCount} priced`);
+
+  if (estimatedCount > 0) {
+    parts.push(`${estimatedCount} estimated`);
+  }
 
   if (usageBasedCount > 0) {
     parts.push(`${usageBasedCount} usage-based`);

--- a/src/output/table.ts
+++ b/src/output/table.ts
@@ -53,6 +53,20 @@ function buildUsageTable(stack: PricedStack, noColor: boolean): string {
   return table.toString();
 }
 
+function buildEstimatedTable(stack: PricedStack, noColor: boolean): string {
+  const headStyle = noColor ? [] : ['cyan'];
+  const table = new Table({
+    head: ['Resource ID', 'Type', 'Monthly Cost', 'Basis'],
+    style: { head: headStyle },
+  });
+
+  for (const r of stack.estimatedResources) {
+    table.push([r.logicalId, r.type, `~${formatCost(r.estimatedMonthlyCost)}`, r.basis]);
+  }
+
+  return table.toString();
+}
+
 function buildConditionalTable(stack: PricedStack, noColor: boolean): string {
   const headStyle = noColor ? [] : ['cyan'];
   const table = new Table({
@@ -77,6 +91,7 @@ export function formatTable(stacks: PricedStack[], noColor: boolean): string {
 
   const totalMonthlyCost = stacks.reduce((sum, s) => sum + s.stackMonthlyCost, 0);
   const hasUsageBased = stacks.some((s) => s.usageBasedResources.length > 0);
+  const hasEstimated = stacks.some((s) => s.estimatedResources.length > 0);
 
   const lines: string[] = [];
 
@@ -86,6 +101,12 @@ export function formatTable(stacks: PricedStack[], noColor: boolean): string {
 
     if (stack.pricedResources.length > 0) {
       lines.push(buildFixedTable(stack, noColor));
+    }
+
+    if (stack.estimatedResources.length > 0) {
+      lines.push(header('Estimated (usage-based with provided estimates)', noColor));
+      lines.push(buildEstimatedTable(stack, noColor));
+      lines.push('~ Estimated using Tier 1 pricing. Actual costs may be lower at high volume.');
     }
 
     if (stack.usageBasedResources.length > 0) {
@@ -104,7 +125,19 @@ export function formatTable(stacks: PricedStack[], noColor: boolean): string {
     lines.push('');
   }
 
-  const totalStr = formatCost(totalMonthlyCost) + (hasUsageBased ? ' + usage-based' : '');
+  const totalEstimated = stacks.reduce(
+    (sum, s) => sum + s.estimatedResources.reduce((s2, r) => s2 + r.estimatedMonthlyCost, 0),
+    0,
+  );
+  const fixedCost = totalMonthlyCost - totalEstimated;
+  let totalStr: string;
+  if (hasEstimated && hasUsageBased) {
+    totalStr = `${formatCost(fixedCost)} + ~${formatCost(totalEstimated)} estimated + usage-based`;
+  } else if (hasEstimated) {
+    totalStr = `${formatCost(fixedCost)} + ~${formatCost(totalEstimated)} estimated`;
+  } else {
+    totalStr = formatCost(totalMonthlyCost) + (hasUsageBased ? ' + usage-based' : '');
+  }
   const totalLine = noColor
     ? `TOTAL ESTIMATED MONTHLY COST: ${totalStr}`
     : chalk.bold(`TOTAL ESTIMATED MONTHLY COST: ${totalStr}`);

--- a/src/output/types.ts
+++ b/src/output/types.ts
@@ -8,12 +8,23 @@ export interface BreakdownResult {
   summary: BreakdownSummary;
 }
 
+export interface EstimatedResult {
+  logicalId: string;
+  type: string;
+  estimatedMonthlyCost: number;
+  currency: 'USD';
+  basis: string;
+  unitPrice: number;
+  unit: string;
+}
+
 export interface PricedStackResult {
   stackId: string;
   region: string;
   regionSource: string;
   resources: ResourceResult[];
   usageBasedResources: UsageBasedResult[];
+  estimatedResources: EstimatedResult[];
   conditionalResources: ConditionalResult[];
   unsupportedTypes: string[];
   stackMonthlyCost: number;

--- a/src/pricing/engine.ts
+++ b/src/pricing/engine.ts
@@ -4,14 +4,17 @@ import type {
   PricedStack,
   PricedResource,
   UsageBasedResource,
+  EstimatedResource,
   PricedConditionalResource,
   PricingApiResult,
   PricingQuery,
+  UsageFile,
 } from './types.js';
 import { buildCacheKey, getFromMemory, getFromFile, setInMemory, setInFile } from './cache.js';
 import { fetchPrice } from './client.js';
 import type { ResourceHandler, PricingAttributes } from '../registry/handler.js';
 import type { ResourceRecord } from '../template/types.js';
+import { calculateEstimatedCost } from './usage-calculator.js';
 
 // ─── Internal work item ───────────────────────────────────────────────────────
 
@@ -71,12 +74,14 @@ export async function priceStacks(
   stacks: ParsedStack[],
   registry: ResourceHandlerRegistry,
   noCache: boolean,
+  usageFile?: UsageFile,
 ): Promise<PricedStack[]> {
   const output: PricedStack[] = [];
 
   for (const stack of stacks) {
     const pricedResources: PricedResource[] = [];
     const usageBasedResources: UsageBasedResource[] = [];
+    const estimatedResources: EstimatedResource[] = [];
     const conditionalResources: PricedConditionalResource[] = [];
     const unsupportedTypes: string[] = [];
 
@@ -181,13 +186,25 @@ export async function priceStacks(
 
         conditionalResources.push(condOut);
       } else if (handler.isUsageBased) {
-        usageBasedResources.push({
+        const usageBasedResource: UsageBasedResource = {
           logicalId: resource.logicalId,
           type: resource.type,
           unitPrice: result.pricePerUnit,
           unit: result.unit,
           currency: 'USD',
-        });
+        };
+
+        const usageEntry = usageFile?.[resource.logicalId];
+        if (usageEntry !== undefined) {
+          const estimated = calculateEstimatedCost(usageBasedResource, usageEntry);
+          if (estimated !== null) {
+            estimatedResources.push(estimated);
+          } else {
+            usageBasedResources.push(usageBasedResource);
+          }
+        } else {
+          usageBasedResources.push(usageBasedResource);
+        }
       } else {
         const monthlyPrice = handler.calculateMonthlyCost(result);
         if (monthlyPrice !== null) {
@@ -202,7 +219,9 @@ export async function priceStacks(
       }
     }
 
-    const stackMonthlyCost = pricedResources.reduce((sum, r) => sum + r.monthlyCost, 0);
+    const stackMonthlyCost =
+      pricedResources.reduce((sum, r) => sum + r.monthlyCost, 0) +
+      estimatedResources.reduce((sum, r) => sum + r.estimatedMonthlyCost, 0);
 
     output.push({
       stackId: stack.stackId,
@@ -210,6 +229,7 @@ export async function priceStacks(
       regionSource: stack.regionSource,
       pricedResources,
       usageBasedResources,
+      estimatedResources,
       conditionalResources,
       unsupportedTypes,
       stackMonthlyCost,

--- a/src/pricing/types.ts
+++ b/src/pricing/types.ts
@@ -32,6 +32,7 @@ export interface PricedStack {
   regionSource: RegionSource;
   pricedResources: PricedResource[];
   usageBasedResources: UsageBasedResource[];
+  estimatedResources: EstimatedResource[];
   conditionalResources: PricedConditionalResource[];
   unsupportedTypes: string[];
   stackMonthlyCost: number;
@@ -58,4 +59,23 @@ export interface CacheEntry {
   result: PricingApiResult;
   cachedAt: number;
   ttlMs: number;
+}
+
+export interface ResourceUsage {
+  requests_per_month?: number;
+  avg_duration_ms?: number;
+  memory_mb?: number;
+  storage_gb?: number;
+}
+
+export type UsageFile = Record<string, ResourceUsage>;
+
+export interface EstimatedResource {
+  logicalId: string;
+  type: string;
+  estimatedMonthlyCost: number;
+  currency: 'USD';
+  basis: string;
+  unitPrice: number;
+  unit: string;
 }

--- a/src/pricing/usage-calculator.ts
+++ b/src/pricing/usage-calculator.ts
@@ -1,0 +1,123 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { load } from 'js-yaml';
+import { StackPriceError } from '../errors/index.js';
+import type { UsageFile, ResourceUsage, EstimatedResource, UsageBasedResource } from './types.js';
+
+export function parseUsageFile(filePath: string): UsageFile {
+  const resolved = path.resolve(filePath);
+  if (!fs.existsSync(resolved)) {
+    throw new StackPriceError(`Usage file not found: ${filePath}`, 2);
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(resolved, 'utf-8') as string;
+  } catch {
+    throw new StackPriceError(`Failed to read usage file: ${filePath}`, 2);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = load(content);
+  } catch {
+    throw new StackPriceError(`Invalid YAML in usage file: ${filePath}`, 2);
+  }
+
+  if (parsed === null || parsed === undefined) {
+    return {};
+  }
+
+  if (typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new StackPriceError(`Usage file must be a YAML mapping of resource IDs to usage values: ${filePath}`, 2);
+  }
+
+  // Validate shape: Record<string, ResourceUsage>
+  const result: UsageFile = {};
+  for (const [key, value] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+      continue; // silently skip invalid entries
+    }
+    const entry = value as Record<string, unknown>;
+    const usage: ResourceUsage = {};
+    if (typeof entry['requests_per_month'] === 'number') {
+      usage.requests_per_month = entry['requests_per_month'];
+    }
+    if (typeof entry['avg_duration_ms'] === 'number') {
+      usage.avg_duration_ms = entry['avg_duration_ms'];
+    }
+    if (typeof entry['memory_mb'] === 'number') {
+      usage.memory_mb = entry['memory_mb'];
+    }
+    if (typeof entry['storage_gb'] === 'number') {
+      usage.storage_gb = entry['storage_gb'];
+    }
+    result[key] = usage;
+  }
+
+  return result;
+}
+
+export function calculateEstimatedCost(
+  resource: UsageBasedResource,
+  usage: ResourceUsage,
+): EstimatedResource | null {
+  try {
+    const { type, logicalId, unitPrice, unit, currency } = resource;
+
+    if (type === 'AWS::Lambda::Function') {
+      const { requests_per_month, avg_duration_ms, memory_mb = 128 } = usage;
+      if (requests_per_month === undefined || avg_duration_ms === undefined) {
+        return null;
+      }
+      const gbSeconds = (memory_mb / 1024) * (avg_duration_ms / 1000) * requests_per_month;
+      const estimatedMonthlyCost = gbSeconds * unitPrice;
+      const basis = `${(requests_per_month / 1e6).toFixed(0)}M req × ${avg_duration_ms}ms × ${memory_mb}MB`;
+      return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+    }
+
+    if (type === 'AWS::S3::Bucket') {
+      const { storage_gb } = usage;
+      if (storage_gb === undefined) {
+        return null;
+      }
+      const estimatedMonthlyCost = storage_gb * unitPrice;
+      const basis = `${storage_gb}GB stored`;
+      return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+    }
+
+    if (type === 'AWS::SQS::Queue') {
+      const { requests_per_month } = usage;
+      if (requests_per_month === undefined) {
+        return null;
+      }
+      const estimatedMonthlyCost = requests_per_month * unitPrice;
+      const basis = `${requests_per_month.toLocaleString()} requests`;
+      return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+    }
+
+    if (type === 'AWS::SNS::Topic') {
+      const { requests_per_month } = usage;
+      if (requests_per_month === undefined) {
+        return null;
+      }
+      const estimatedMonthlyCost = requests_per_month * unitPrice;
+      const basis = `${requests_per_month.toLocaleString()} notifications`;
+      return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+    }
+
+    if (type === 'AWS::ApiGateway::RestApi') {
+      const { requests_per_month } = usage;
+      if (requests_per_month === undefined) {
+        return null;
+      }
+      const estimatedMonthlyCost = requests_per_month * unitPrice;
+      const basis = `${requests_per_month.toLocaleString()} requests`;
+      return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/cli/parser.test.ts
+++ b/tests/unit/cli/parser.test.ts
@@ -46,6 +46,13 @@ vi.mock('../../../src/pricing/engine.js', () => ({
   priceStacks: (...args: unknown[]): unknown => mockPriceStacks(...args),
 }));
 
+const mockParseUsageFile = vi.fn();
+
+vi.mock('../../../src/pricing/usage-calculator.js', () => ({
+  parseUsageFile: (...args: unknown[]): unknown => mockParseUsageFile(...args),
+  calculateEstimatedCost: vi.fn(),
+}));
+
 const mockFormatTable = vi.fn();
 
 vi.mock('../../../src/output/table.js', () => ({
@@ -141,6 +148,7 @@ function makePricedStack(stackId: string): PricedStack {
     regionSource: 'template',
     pricedResources: [],
     usageBasedResources: [],
+    estimatedResources: [],
     conditionalResources: [],
     unsupportedTypes: [],
     stackMonthlyCost: 0,
@@ -392,6 +400,46 @@ describe('createProgram — breakdown command', () => {
 
     const [, , noCacheArg] = mockPriceStacks.mock.calls[0] as [unknown, unknown, boolean];
     expect(noCacheArg).toBe(true);
+  });
+
+  it('--usage-file: parseUsageFile called with correct path and result passed to priceStacks', async () => {
+    const usageData = { MyLambda: { requests_per_month: 5000000, avg_duration_ms: 200 } };
+    mockParseUsageFile.mockReturnValue(usageData);
+
+    mockCheckCredentials.mockResolvedValue(undefined);
+    mockReadAssembly.mockReturnValue(fakeAssembly);
+    mockParseStacks.mockReturnValue([makeParsedStack('MyStack')]);
+    mockPriceStacks.mockResolvedValue([makePricedStack('MyStack')]);
+    mockFormatTable.mockReturnValue('output');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'breakdown',
+      '--dir', '/fake/cdk.out',
+      '--usage-file', '/fake/usage.yml',
+    ]);
+
+    expect(mockParseUsageFile).toHaveBeenCalledWith('/fake/usage.yml');
+    const [, , , usageFileArg] = mockPriceStacks.mock.calls[0] as [unknown, unknown, unknown, unknown];
+    expect(usageFileArg).toEqual(usageData);
+  });
+
+  it('--usage-file missing: parseUsageFile not called and undefined passed to priceStacks', async () => {
+    mockCheckCredentials.mockResolvedValue(undefined);
+    mockReadAssembly.mockReturnValue(fakeAssembly);
+    mockParseStacks.mockReturnValue([makeParsedStack('MyStack')]);
+    mockPriceStacks.mockResolvedValue([makePricedStack('MyStack')]);
+    mockFormatTable.mockReturnValue('output');
+
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'breakdown',
+      '--dir', '/fake/cdk.out',
+    ]);
+
+    expect(mockParseUsageFile).not.toHaveBeenCalled();
+    const [, , , usageFileArg] = mockPriceStacks.mock.calls[0] as [unknown, unknown, unknown, unknown];
+    expect(usageFileArg).toBeUndefined();
   });
 });
 

--- a/tests/unit/output/diff.test.ts
+++ b/tests/unit/output/diff.test.ts
@@ -54,6 +54,7 @@ function makeStack(overrides: Partial<PricedStackResult> = {}): PricedStackResul
     regionSource: 'template',
     resources: [makeResource()],
     usageBasedResources: [],
+    estimatedResources: [],
     conditionalResources: [],
     unsupportedTypes: [],
     stackMonthlyCost: 70.08,

--- a/tests/unit/output/json.test.ts
+++ b/tests/unit/output/json.test.ts
@@ -19,6 +19,7 @@ function makeStack(overrides: Partial<PricedStack> = {}): PricedStack {
       },
     ],
     usageBasedResources: [],
+    estimatedResources: [],
     conditionalResources: [],
     unsupportedTypes: [],
     stackMonthlyCost: 70.08,

--- a/tests/unit/output/summary.test.ts
+++ b/tests/unit/output/summary.test.ts
@@ -19,6 +19,7 @@ function makeStack(overrides: Partial<PricedStack> = {}): PricedStack {
       },
     ],
     usageBasedResources: [],
+    estimatedResources: [],
     conditionalResources: [],
     unsupportedTypes: [],
     stackMonthlyCost: 70.08,

--- a/tests/unit/output/table.test.ts
+++ b/tests/unit/output/table.test.ts
@@ -26,6 +26,7 @@ function makeStack(overrides: Partial<PricedStack> = {}): PricedStack {
       },
     ],
     usageBasedResources: [],
+    estimatedResources: [],
     conditionalResources: [],
     unsupportedTypes: [],
     stackMonthlyCost: 172.65,
@@ -145,6 +146,87 @@ describe('formatTable', () => {
       expect(result).toContain('ConditionalLambda');
       expect(result).toContain('IsEnabled');
       expect(result).toContain('Usage-based');
+    });
+  });
+
+  describe('estimated resources', () => {
+    it('shows estimated table section when estimatedResources is non-empty', () => {
+      const stack = makeStack({
+        estimatedResources: [
+          {
+            logicalId: 'ApiHandler5E7490E8',
+            type: 'AWS::Lambda::Function',
+            estimatedMonthlyCost: 4.17,
+            currency: 'USD',
+            basis: '5M req × 200ms × 256MB',
+            unitPrice: 0.0000166667,
+            unit: 'GB-second',
+          },
+        ],
+        stackMonthlyCost: 172.65 + 4.17,
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('ApiHandler5E7490E8');
+      expect(result).toContain('Estimated (usage-based with provided estimates)');
+      expect(result).toContain('~$4.17');
+      expect(result).toContain('5M req × 200ms × 256MB');
+      expect(result).toContain('~ Estimated using Tier 1 pricing');
+    });
+
+    it('does not show estimated table section when estimatedResources is empty', () => {
+      const result = formatTable([makeStack()], true);
+      expect(result).not.toContain('Estimated (usage-based with provided estimates)');
+      expect(result).not.toContain('~ Estimated using Tier 1 pricing');
+    });
+
+    it('shows fixed + estimated total when only estimated (no remaining usage-based)', () => {
+      const stack = makeStack({
+        pricedResources: [
+          { logicalId: 'Ec2Instance', type: 'AWS::EC2::Instance', monthlyCost: 70.08, currency: 'USD', basis: 'Hrs' },
+        ],
+        estimatedResources: [
+          {
+            logicalId: 'MyLambda',
+            type: 'AWS::Lambda::Function',
+            estimatedMonthlyCost: 4.17,
+            currency: 'USD',
+            basis: '5M req × 200ms × 256MB',
+            unitPrice: 0.0000166667,
+            unit: 'GB-second',
+          },
+        ],
+        usageBasedResources: [],
+        stackMonthlyCost: 74.25,
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('+ ~$4.17 estimated');
+      expect(result).not.toContain('+ usage-based');
+    });
+
+    it('shows fixed + estimated + usage-based total when both estimated and usage-based exist', () => {
+      const stack = makeStack({
+        pricedResources: [
+          { logicalId: 'Ec2Instance', type: 'AWS::EC2::Instance', monthlyCost: 70.08, currency: 'USD', basis: 'Hrs' },
+        ],
+        estimatedResources: [
+          {
+            logicalId: 'MyLambda',
+            type: 'AWS::Lambda::Function',
+            estimatedMonthlyCost: 4.17,
+            currency: 'USD',
+            basis: '5M req × 200ms × 256MB',
+            unitPrice: 0.0000166667,
+            unit: 'GB-second',
+          },
+        ],
+        usageBasedResources: [
+          { logicalId: 'MyBucket', type: 'AWS::S3::Bucket', unitPrice: 0.023, unit: 'GB-Mo', currency: 'USD' },
+        ],
+        stackMonthlyCost: 74.25,
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('estimated');
+      expect(result).toContain('usage-based');
     });
   });
 

--- a/tests/unit/pricing/engine.test.ts
+++ b/tests/unit/pricing/engine.test.ts
@@ -25,6 +25,13 @@ vi.mock('../../../src/pricing/client.js', () => ({
   fetchPrice: (...args: unknown[]): unknown => mockFetchPrice(...args),
 }));
 
+const mockCalculateEstimatedCost = vi.fn();
+
+vi.mock('../../../src/pricing/usage-calculator.js', () => ({
+  calculateEstimatedCost: (...args: unknown[]): unknown => mockCalculateEstimatedCost(...args),
+  parseUsageFile: vi.fn(),
+}));
+
 import { priceStacks } from '../../../src/pricing/engine.js';
 import { ResourceHandlerRegistry } from '../../../src/registry/index.js';
 
@@ -106,6 +113,8 @@ beforeEach(() => {
   mockBuildCacheKey.mockReturnValue('us-east-1:AmazonEC2:instanceType=m5.large');
   mockGetFromMemory.mockReturnValue(null);
   mockGetFromFile.mockReturnValue(null);
+  // Default: calculateEstimatedCost returns null (no estimate)
+  mockCalculateEstimatedCost.mockReturnValue(null);
 });
 
 describe('priceStacks', () => {
@@ -592,6 +601,112 @@ describe('priceStacks', () => {
 
       expect(result!.conditionalResources).toHaveLength(1);
       expect(result!.conditionalResources[0]!.monthlyCost).toBeCloseTo(0.04048 * 730 * 0.25, 4);
+    });
+  });
+
+  describe('usageFile parameter', () => {
+    it('usageFile undefined: estimatedResources is empty array', async () => {
+      const apiResult = makeApiResult(0.0000002, 'Requests');
+      mockBuildCacheKey.mockReturnValue('us-east-1:AWSLambda:location=us-east-1');
+      mockFetchPrice.mockResolvedValue(apiResult);
+
+      const handler = makeUsageHandler();
+      const stack = makeStack([makeResource('MyLambda', 'AWS::Lambda::Function')]);
+      const registry = makeRegistry(handler);
+
+      const [result] = await priceStacks([stack], registry, false);
+
+      expect(result!.estimatedResources).toHaveLength(0);
+      expect(result!.usageBasedResources).toHaveLength(1);
+      expect(mockCalculateEstimatedCost).not.toHaveBeenCalled();
+    });
+
+    it('usageFile provided: resource in file and calculateEstimatedCost returns non-null moves to estimatedResources', async () => {
+      const apiResult = makeApiResult(0.0000166667, 'GB-second');
+      mockBuildCacheKey.mockReturnValue('us-east-1:AWSLambda:location=us-east-1');
+      mockFetchPrice.mockResolvedValue(apiResult);
+
+      const estimatedResult = {
+        logicalId: 'MyLambda',
+        type: 'AWS::Lambda::Function',
+        estimatedMonthlyCost: 4.17,
+        currency: 'USD' as const,
+        basis: '5M req × 200ms × 256MB',
+        unitPrice: 0.0000166667,
+        unit: 'GB-second',
+      };
+      mockCalculateEstimatedCost.mockReturnValue(estimatedResult);
+
+      const handler = makeUsageHandler();
+      const stack = makeStack([makeResource('MyLambda', 'AWS::Lambda::Function')]);
+      const registry = makeRegistry(handler);
+
+      const usageFile = { MyLambda: { requests_per_month: 5000000, avg_duration_ms: 200, memory_mb: 256 } };
+      const [result] = await priceStacks([stack], registry, false, usageFile);
+
+      expect(result!.estimatedResources).toHaveLength(1);
+      expect(result!.estimatedResources[0]).toMatchObject(estimatedResult);
+      expect(result!.usageBasedResources).toHaveLength(0);
+    });
+
+    it('usageFile provided: estimated cost included in stackMonthlyCost', async () => {
+      const apiResult = makeApiResult(0.0000166667, 'GB-second');
+      mockBuildCacheKey.mockReturnValue('us-east-1:AWSLambda:location=us-east-1');
+      mockFetchPrice.mockResolvedValue(apiResult);
+
+      mockCalculateEstimatedCost.mockReturnValue({
+        logicalId: 'MyLambda',
+        type: 'AWS::Lambda::Function',
+        estimatedMonthlyCost: 4.17,
+        currency: 'USD' as const,
+        basis: '5M req × 200ms × 256MB',
+        unitPrice: 0.0000166667,
+        unit: 'GB-second',
+      });
+
+      const handler = makeUsageHandler();
+      const stack = makeStack([makeResource('MyLambda', 'AWS::Lambda::Function')]);
+      const registry = makeRegistry(handler);
+
+      const usageFile = { MyLambda: { requests_per_month: 5000000, avg_duration_ms: 200, memory_mb: 256 } };
+      const [result] = await priceStacks([stack], registry, false, usageFile);
+
+      expect(result!.stackMonthlyCost).toBeCloseTo(4.17);
+    });
+
+    it('usageFile provided: resource not in file stays in usageBasedResources', async () => {
+      const apiResult = makeApiResult(0.0000166667, 'GB-second');
+      mockBuildCacheKey.mockReturnValue('us-east-1:AWSLambda:location=us-east-1');
+      mockFetchPrice.mockResolvedValue(apiResult);
+
+      const handler = makeUsageHandler();
+      const stack = makeStack([makeResource('MyLambda', 'AWS::Lambda::Function')]);
+      const registry = makeRegistry(handler);
+
+      const usageFile = { OtherResource: { requests_per_month: 1000000 } };
+      const [result] = await priceStacks([stack], registry, false, usageFile);
+
+      expect(result!.usageBasedResources).toHaveLength(1);
+      expect(result!.estimatedResources).toHaveLength(0);
+      expect(mockCalculateEstimatedCost).not.toHaveBeenCalled();
+    });
+
+    it('usageFile provided: resource in file but calculateEstimatedCost returns null stays in usageBasedResources', async () => {
+      const apiResult = makeApiResult(0.0000166667, 'GB-second');
+      mockBuildCacheKey.mockReturnValue('us-east-1:AWSLambda:location=us-east-1');
+      mockFetchPrice.mockResolvedValue(apiResult);
+
+      mockCalculateEstimatedCost.mockReturnValue(null);
+
+      const handler = makeUsageHandler();
+      const stack = makeStack([makeResource('MyLambda', 'AWS::Lambda::Function')]);
+      const registry = makeRegistry(handler);
+
+      const usageFile = { MyLambda: { requests_per_month: 5000000 } };
+      const [result] = await priceStacks([stack], registry, false, usageFile);
+
+      expect(result!.usageBasedResources).toHaveLength(1);
+      expect(result!.estimatedResources).toHaveLength(0);
     });
   });
 

--- a/tests/unit/pricing/usage-calculator.test.ts
+++ b/tests/unit/pricing/usage-calculator.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { UsageBasedResource } from '../../../src/pricing/types.js';
+import { StackPriceError } from '../../../src/errors/index.js';
+
+// ─── fs mock ─────────────────────────────────────────────────────────────────
+
+const mockExistsSync = vi.fn();
+const mockReadFileSync = vi.fn();
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: (...args: unknown[]): unknown => mockExistsSync(...args),
+    readFileSync: (...args: unknown[]): unknown => mockReadFileSync(...args),
+  };
+});
+
+// ─── js-yaml mock ─────────────────────────────────────────────────────────────
+
+const mockYamlLoad = vi.fn();
+
+vi.mock('js-yaml', () => ({
+  load: (...args: unknown[]): unknown => mockYamlLoad(...args),
+}));
+
+import { parseUsageFile, calculateEstimatedCost } from '../../../src/pricing/usage-calculator.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeUsageBasedResource(overrides: Partial<UsageBasedResource> = {}): UsageBasedResource {
+  return {
+    logicalId: 'MyResource',
+    type: 'AWS::Lambda::Function',
+    unitPrice: 0.0000166667,
+    unit: 'GB-second',
+    currency: 'USD',
+    ...overrides,
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('parseUsageFile', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns correct UsageFile for valid YAML', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('yaml content');
+    mockYamlLoad.mockReturnValue({
+      MyLambda: { requests_per_month: 5000000, avg_duration_ms: 200, memory_mb: 256 },
+      MyBucket: { storage_gb: 500 },
+    });
+
+    const result = parseUsageFile('/some/usage.yml');
+    expect(result).toEqual({
+      MyLambda: { requests_per_month: 5000000, avg_duration_ms: 200, memory_mb: 256 },
+      MyBucket: { storage_gb: 500 },
+    });
+  });
+
+  it('returns empty object for null/empty YAML', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('');
+    mockYamlLoad.mockReturnValue(null);
+
+    const result = parseUsageFile('/some/usage.yml');
+    expect(result).toEqual({});
+  });
+
+  it('silently ignores entries with non-number usage values', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('yaml content');
+    mockYamlLoad.mockReturnValue({
+      MyLambda: { requests_per_month: '5000000' },  // string, not number
+      MyBucket: { storage_gb: 500 },
+    });
+
+    const result = parseUsageFile('/some/usage.yml');
+    expect(result).toEqual({
+      MyLambda: {},
+      MyBucket: { storage_gb: 500 },
+    });
+  });
+
+  it('throws StackPriceError when file not found', () => {
+    mockExistsSync.mockReturnValue(false);
+
+    expect(() => parseUsageFile('/missing/usage.yml')).toThrow(StackPriceError);
+    expect(() => parseUsageFile('/missing/usage.yml')).toThrow('Usage file not found');
+  });
+
+  it('throws StackPriceError when readFileSync throws', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('permission denied');
+    });
+
+    expect(() => parseUsageFile('/some/usage.yml')).toThrow(StackPriceError);
+    expect(() => parseUsageFile('/some/usage.yml')).toThrow('Failed to read usage file');
+  });
+
+  it('throws StackPriceError for invalid YAML', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('invalid: yaml: content:');
+    mockYamlLoad.mockImplementation(() => {
+      throw new Error('bad yaml');
+    });
+
+    expect(() => parseUsageFile('/some/usage.yml')).toThrow(StackPriceError);
+    expect(() => parseUsageFile('/some/usage.yml')).toThrow('Invalid YAML');
+  });
+
+  it('throws StackPriceError when YAML is an array (not a mapping)', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('- item');
+    mockYamlLoad.mockReturnValue(['item']);
+
+    expect(() => parseUsageFile('/some/usage.yml')).toThrow(StackPriceError);
+  });
+
+  it('silently skips entries where value is a primitive (string)', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('yaml content');
+    mockYamlLoad.mockReturnValue({
+      MyLambda: 'not-an-object',   // string, should be omitted entirely
+      MyBucket: { storage_gb: 500 },
+    });
+
+    const result = parseUsageFile('/some/usage.yml');
+    expect(result).toEqual({ MyBucket: { storage_gb: 500 } });
+    expect('MyLambda' in result).toBe(false);
+  });
+});
+
+describe('calculateEstimatedCost', () => {
+  describe('AWS::Lambda::Function', () => {
+    it('calculates cost with all fields', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::Lambda::Function',
+        unitPrice: 0.0000166667,
+        unit: 'GB-second',
+      });
+      const usage = { requests_per_month: 5000000, avg_duration_ms: 200, memory_mb: 256 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      expect(result!.type).toBe('AWS::Lambda::Function');
+      expect(result!.logicalId).toBe('MyResource');
+      expect(result!.unitPrice).toBe(0.0000166667);
+      expect(result!.unit).toBe('GB-second');
+      expect(result!.currency).toBe('USD');
+      // GB-seconds = (256/1024) * (200/1000) * 5000000 = 0.25 * 0.2 * 5000000 = 250000
+      // cost = 250000 * 0.0000166667 ≈ 4.16667
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(4.16667, 2);
+      expect(result!.basis).toContain('req');
+      expect(result!.basis).toContain('200ms');
+      expect(result!.basis).toContain('256MB');
+    });
+
+    it('defaults memory_mb to 128 when not provided', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::Lambda::Function',
+        unitPrice: 0.0000166667,
+        unit: 'GB-second',
+      });
+      const usage = { requests_per_month: 1000000, avg_duration_ms: 100 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      // GB-seconds = (128/1024) * (100/1000) * 1000000 = 0.125 * 0.1 * 1000000 = 12500
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(12500 * 0.0000166667, 2);
+    });
+
+    it('returns null when avg_duration_ms is missing', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::Lambda::Function' });
+      const usage = { requests_per_month: 5000000 };
+      expect(calculateEstimatedCost(resource, usage)).toBeNull();
+    });
+
+    it('returns null when requests_per_month is missing', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::Lambda::Function' });
+      const usage = { avg_duration_ms: 200, memory_mb: 256 };
+      expect(calculateEstimatedCost(resource, usage)).toBeNull();
+    });
+  });
+
+  describe('AWS::S3::Bucket', () => {
+    it('calculates cost with storage_gb', () => {
+      const resource = makeUsageBasedResource({
+        logicalId: 'DataBucket',
+        type: 'AWS::S3::Bucket',
+        unitPrice: 0.023,
+        unit: 'GB-Mo',
+      });
+      const usage = { storage_gb: 500 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(500 * 0.023, 5);
+      expect(result!.basis).toContain('500GB');
+    });
+
+    it('returns null when storage_gb is missing', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::S3::Bucket' });
+      expect(calculateEstimatedCost(resource, {})).toBeNull();
+    });
+  });
+
+  describe('AWS::SQS::Queue', () => {
+    it('calculates cost with requests_per_month', () => {
+      const resource = makeUsageBasedResource({
+        logicalId: 'JobQueue',
+        type: 'AWS::SQS::Queue',
+        unitPrice: 0.0000004,
+        unit: 'Requests',
+      });
+      const usage = { requests_per_month: 10000000 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(10000000 * 0.0000004, 5);
+      expect(result!.basis).toContain('requests');
+    });
+
+    it('returns null when requests_per_month is missing', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::SQS::Queue' });
+      expect(calculateEstimatedCost(resource, {})).toBeNull();
+    });
+  });
+
+  describe('AWS::SNS::Topic', () => {
+    it('calculates cost with requests_per_month', () => {
+      const resource = makeUsageBasedResource({
+        logicalId: 'AlertTopic',
+        type: 'AWS::SNS::Topic',
+        unitPrice: 0.0000005,
+        unit: 'Requests',
+      });
+      const usage = { requests_per_month: 1000000 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(1000000 * 0.0000005, 5);
+      expect(result!.basis).toContain('notification');
+    });
+
+    it('returns null when requests_per_month is missing', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::SNS::Topic' });
+      expect(calculateEstimatedCost(resource, {})).toBeNull();
+    });
+  });
+
+  describe('AWS::ApiGateway::RestApi', () => {
+    it('calculates cost with requests_per_month', () => {
+      const resource = makeUsageBasedResource({
+        logicalId: 'MyApi',
+        type: 'AWS::ApiGateway::RestApi',
+        unitPrice: 0.0000035,
+        unit: 'Requests',
+      });
+      const usage = { requests_per_month: 2000000 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(2000000 * 0.0000035, 5);
+      expect(result!.basis).toContain('requests');
+    });
+
+    it('returns null when requests_per_month is missing', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::ApiGateway::RestApi' });
+      expect(calculateEstimatedCost(resource, {})).toBeNull();
+    });
+  });
+
+  describe('unknown resource type', () => {
+    it('returns null for an unrecognised type', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::Unknown::Resource' });
+      const usage = { requests_per_month: 1000000 };
+      expect(calculateEstimatedCost(resource, usage)).toBeNull();
+    });
+  });
+
+  describe('catch-all safety net', () => {
+    it('returns null when resource is null/undefined (runtime type violation)', () => {
+      // Test the catch block — never throws, always returns null
+      const result = calculateEstimatedCost(
+        null as unknown as ReturnType<typeof makeUsageBasedResource>,
+        {},
+      );
+      expect(result).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Adding support for calculating the cost estimates based on the usage ranges for supported resources