### PR TITLE
chore: error message colors, strip CDK hash in table, sort usage-based by price

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { Command } from 'commander';
+import chalk from 'chalk';
 
 import { checkCredentials } from '../pricing/credentials.js';
 import { readAssembly } from '../assembly/reader.js';
@@ -128,6 +129,8 @@ export function createProgram(): Command {
       const noCache = !options.cache;
       const output = options.output as 'table' | 'json' | 'summary';
 
+      chalk.level = noColor ? 0 : 3;
+
       try {
         // ── 2. Check credentials ─────────────────────────────────────────────
         await checkCredentials();
@@ -184,16 +187,21 @@ export function createProgram(): Command {
         }
       } catch (err: unknown) {
         if (err instanceof StackPriceError) {
-          process.stderr.write(`Error: ${err.message}\n`);
+          process.stderr.write(chalk.red(`✗ ${err.message}\n`));
           if (options.verbose && err.stack) {
             process.stderr.write(`${err.stack}\n`);
           }
           process.exit(err.exitCode);
         } else {
-          const hint = options.verbose ? '' : ' Use --verbose for details.';
-          process.stderr.write(`An unexpected error occurred.${hint}\n`);
-          if (options.verbose && err instanceof Error && err.stack) {
-            process.stderr.write(`${err.stack}\n`);
+          if (options.verbose) {
+            const msg = err instanceof Error ? err.message : String(err);
+            process.stderr.write(chalk.red(`An unexpected error occurred: ${msg}\n`));
+            if (err instanceof Error && err.stack) {
+              process.stderr.write(`${err.stack}\n`);
+            }
+          } else {
+            process.stderr.write(chalk.red(`An unexpected error occurred.\n`));
+            process.stderr.write(`Use --verbose for details.\n`);
           }
           process.exit(2);
         }
@@ -212,6 +220,8 @@ export function createProgram(): Command {
     .option('--out-file <path>', 'Write output to file instead of stdout (optional)')
     .action((beforeArg: string, afterArg: string, options: DiffOptions) => {
       const noColor = !options.color;
+
+      chalk.level = noColor ? 0 : 3;
 
       try {
         // ── 1. Validate paths (Security Rule 1 — path validation) ────────────
@@ -284,10 +294,10 @@ export function createProgram(): Command {
         }
       } catch (err: unknown) {
         if (err instanceof StackPriceError) {
-          process.stderr.write(`Error: ${err.message}\n`);
+          process.stderr.write(chalk.red(`✗ ${err.message}\n`));
           process.exit(err.exitCode);
         } else {
-          process.stderr.write(`An unexpected error occurred.\n`);
+          process.stderr.write(chalk.red(`An unexpected error occurred.\n`));
           process.exit(2);
         }
       }

--- a/src/output/table.ts
+++ b/src/output/table.ts
@@ -20,6 +20,19 @@ function header(label: string, noColor: boolean): string {
   return noColor ? label : chalk.bold(label);
 }
 
+/**
+ * Strips the 8-character CDK hash suffix from a logical ID for display.
+ * CDK auto-generates suffixes like "99EDD300" (all [0-9A-F], first 4 contain
+ * at least one letter A-F). The full logicalId is preserved in JSON output.
+ */
+function stripCdkHash(logicalId: string): string {
+  if (logicalId.length <= 8) return logicalId;
+  const suffix = logicalId.slice(-8);
+  if (!/^[0-9A-F]{8}$/.test(suffix)) return logicalId;
+  if (!/[A-F]/.test(suffix.slice(0, 4))) return logicalId;
+  return logicalId.slice(0, -8);
+}
+
 function buildFixedTable(stack: PricedStack, noColor: boolean): string {
   const sorted = [...stack.pricedResources].sort((a, b) => b.monthlyCost - a.monthlyCost);
 
@@ -30,7 +43,7 @@ function buildFixedTable(stack: PricedStack, noColor: boolean): string {
   });
 
   for (const r of sorted) {
-    table.push([r.logicalId, r.type, formatCost(r.monthlyCost)]);
+    table.push([stripCdkHash(r.logicalId), r.type, formatCost(r.monthlyCost)]);
   }
 
   const subtotalLabel = noColor ? 'Stack Subtotal' : chalk.bold('Stack Subtotal');
@@ -46,8 +59,9 @@ function buildUsageTable(stack: PricedStack, noColor: boolean): string {
     style: { head: headStyle },
   });
 
-  for (const r of stack.usageBasedResources) {
-    table.push([r.logicalId, r.type, `${formatUnitPrice(r.unitPrice)}/unit`, 'Usage-based — provide estimate via --usage-file']);
+  const sorted = [...stack.usageBasedResources].sort((a, b) => b.unitPrice - a.unitPrice);
+  for (const r of sorted) {
+    table.push([stripCdkHash(r.logicalId), r.type, `${formatUnitPrice(r.unitPrice)}/unit`, 'Usage-based — provide estimate via --usage-file']);
   }
 
   return table.toString();
@@ -61,7 +75,7 @@ function buildEstimatedTable(stack: PricedStack, noColor: boolean): string {
   });
 
   for (const r of stack.estimatedResources) {
-    table.push([r.logicalId, r.type, `~${formatCost(r.estimatedMonthlyCost)}`, r.basis]);
+    table.push([stripCdkHash(r.logicalId), r.type, `~${formatCost(r.estimatedMonthlyCost)}`, r.basis]);
   }
 
   return table.toString();
@@ -76,7 +90,7 @@ function buildConditionalTable(stack: PricedStack, noColor: boolean): string {
 
   for (const r of stack.conditionalResources) {
     const costStr = r.monthlyCost !== null ? formatCost(r.monthlyCost) : 'Usage-based';
-    table.push([r.logicalId, r.type, r.conditionName, costStr]);
+    table.push([stripCdkHash(r.logicalId), r.type, r.conditionName, costStr]);
   }
 
   return table.toString();
@@ -140,7 +154,7 @@ export function formatTable(stacks: PricedStack[], noColor: boolean): string {
   }
   const totalLine = noColor
     ? `TOTAL ESTIMATED MONTHLY COST: ${totalStr}`
-    : chalk.bold(`TOTAL ESTIMATED MONTHLY COST: ${totalStr}`);
+    : chalk.bold.green(`TOTAL ESTIMATED MONTHLY COST: ${totalStr}`);
 
   lines.push(totalLine);
 

--- a/src/pricing/region.ts
+++ b/src/pricing/region.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+import chalk from 'chalk';
+
 import type { RegionSource } from '../template/types.js';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -133,8 +135,10 @@ export function resolveRegion(
 
   // Step 6: Default fallback — warn to stderr (Security Rule 7: warnings → stderr).
   process.stderr.write(
-    `⚠ Region not determined. Defaulting to ${DEFAULT_REGION}.\n` +
-      `  Use --region to specify a region explicitly.\n`,
+    chalk.yellow(
+      `⚠ Region not determined. Defaulting to ${DEFAULT_REGION}.\n` +
+        `  Use --region to specify a region explicitly.\n`,
+    ),
   );
 
   return { region: DEFAULT_REGION, source: 'default-fallback' };

--- a/tests/unit/cli/parser.test.ts
+++ b/tests/unit/cli/parser.test.ts
@@ -230,23 +230,39 @@ describe('createProgram — breakdown command', () => {
     const program = createProgram();
     await program.parseAsync(['node', 'stackprice', 'breakdown', '--dir', '/fake/cdk.out']);
 
-    expect(mockStderr).toHaveBeenCalledWith('Error: No credentials found\n');
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('No credentials found'));
     expect(mockExit).toHaveBeenCalledWith(EXIT_CODES.FAILURE);
   });
 
-  it('unknown error caught without --verbose → hint included in message', async () => {
+  it('StackPriceError caught with --no-color → plain text (no ANSI codes)', async () => {
+    const { StackPriceError, EXIT_CODES } = await import('../../../src/errors/index.js');
+
+    mockCheckCredentials.mockRejectedValue(
+      new StackPriceError('No credentials found', EXIT_CODES.FAILURE),
+    );
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'breakdown', '--dir', '/fake/cdk.out', '--no-color']);
+
+    const stderrCalls = mockStderr.mock.calls.map((c: unknown[]) => String(c[0]));
+    const errorLine = stderrCalls.find((s: string) => s.includes('No credentials found'));
+    expect(errorLine).toBeDefined();
+    // With noColor, no ANSI escape codes
+    expect(errorLine).not.toMatch(/\x1b\[/);
+  });
+
+  it('unknown error caught without --verbose → two writes: colored message + plain hint', async () => {
     mockCheckCredentials.mockRejectedValue(new Error('unexpected failure'));
 
     const program = createProgram();
     await program.parseAsync(['node', 'stackprice', 'breakdown', '--dir', '/fake/cdk.out']);
 
-    expect(mockStderr).toHaveBeenCalledWith(
-      'An unexpected error occurred. Use --verbose for details.\n',
-    );
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('An unexpected error occurred'));
+    expect(mockStderr).toHaveBeenCalledWith('Use --verbose for details.\n');
     expect(mockExit).toHaveBeenCalledWith(2);
   });
 
-  it('unknown error caught with --verbose → no hint, stack trace printed', async () => {
+  it('unknown error caught with --verbose → message includes error text, stack trace printed', async () => {
     const err = new Error('unexpected failure');
     mockCheckCredentials.mockRejectedValue(err);
 
@@ -257,7 +273,8 @@ describe('createProgram — breakdown command', () => {
       '--verbose',
     ]);
 
-    expect(mockStderr).toHaveBeenCalledWith('An unexpected error occurred.\n');
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('An unexpected error occurred'));
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('unexpected failure'));
     expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('Error: unexpected failure'));
     expect(mockStderr).not.toHaveBeenCalledWith(
       expect.stringContaining('Use --verbose'),
@@ -621,7 +638,7 @@ describe('createProgram — diff command', () => {
     const program = createProgram();
     await program.parseAsync(['node', 'stackprice', 'diff', '/fake/before.json', '/fake/after.json']);
 
-    expect(mockStderr).toHaveBeenCalledWith('An unexpected error occurred.\n');
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('An unexpected error occurred'));
     expect(mockStderr).not.toHaveBeenCalledWith(
       expect.stringContaining('Use --verbose'),
     );

--- a/tests/unit/output/table.test.ts
+++ b/tests/unit/output/table.test.ts
@@ -166,7 +166,9 @@ describe('formatTable', () => {
         stackMonthlyCost: 172.65 + 4.17,
       });
       const result = formatTable([stack], true);
-      expect(result).toContain('ApiHandler5E7490E8');
+      // CDK hash suffix "5E7490E8" is stripped — displays as "ApiHandler"
+      expect(result).toContain('ApiHandler');
+      expect(result).not.toContain('ApiHandler5E7490E8');
       expect(result).toContain('Estimated (usage-based with provided estimates)');
       expect(result).toContain('~$4.17');
       expect(result).toContain('5M req × 200ms × 256MB');
@@ -249,6 +251,104 @@ describe('formatTable', () => {
       const stack = makeStack({ unsupportedTypes: ['AWS::CloudFront::Distribution'] });
       const result = formatTable([stack], true);
       expect(result).toContain('AWS::CloudFront::Distribution');
+    });
+  });
+
+  describe('CDK hash stripping', () => {
+    it('strips 8-char uppercase hex suffix from logicalId (fixed table)', () => {
+      const stack = makeStack({
+        pricedResources: [
+          { logicalId: 'WebServer99EDD300', type: 'AWS::EC2::Instance', monthlyCost: 50.00, currency: 'USD', basis: 'Hrs' },
+        ],
+        stackMonthlyCost: 50.00,
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('WebServer');
+      expect(result).not.toContain('WebServer99EDD300');
+    });
+
+    it('does not strip logicalId with no CDK hash suffix', () => {
+      const stack = makeStack({
+        pricedResources: [
+          { logicalId: 'RedisCluster', type: 'AWS::ElastiCache::ReplicationGroup', monthlyCost: 30.00, currency: 'USD', basis: 'Hrs' },
+        ],
+        stackMonthlyCost: 30.00,
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('RedisCluster');
+    });
+
+    it('does not strip logicalId where first half of suffix has no hex letters (not a CDK hash)', () => {
+      // "49610EDF": first 4 chars "4961" have no A-F letters → keep as-is
+      const stack = makeStack({
+        pricedResources: [
+          { logicalId: 'MyApi49610EDF', type: 'AWS::ApiGateway::RestApi', monthlyCost: 10.00, currency: 'USD', basis: 'Hrs' },
+        ],
+        stackMonthlyCost: 10.00,
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('MyApi49610EDF');
+    });
+
+    it('strips CDK hash suffix in usage-based table', () => {
+      const stack = makeStack({
+        pricedResources: [],
+        stackMonthlyCost: 0,
+        usageBasedResources: [
+          { logicalId: 'DatabaseB269D8BB', type: 'AWS::DynamoDB::Table', unitPrice: 0.00065, unit: 'RCU', currency: 'USD' },
+        ],
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('Database');
+      expect(result).not.toContain('DatabaseB269D8BB');
+    });
+
+    it('strips CDK hash suffix in conditional table', () => {
+      const stack = makeStack({
+        conditionalResources: [
+          { logicalId: 'ProdOnlyBucketCA72566A', type: 'AWS::S3::Bucket', conditionName: 'IsProd', monthlyCost: null, currency: 'USD' },
+        ],
+      });
+      const result = formatTable([stack], true);
+      expect(result).toContain('ProdOnlyBucket');
+      expect(result).not.toContain('ProdOnlyBucketCA72566A');
+    });
+  });
+
+  describe('usage-based sort', () => {
+    it('sorts usage-based resources by unitPrice descending', () => {
+      const stack = makeStack({
+        pricedResources: [],
+        stackMonthlyCost: 0,
+        usageBasedResources: [
+          { logicalId: 'CheapResource', type: 'AWS::SQS::Queue', unitPrice: 0.0000004, unit: 'Requests', currency: 'USD' },
+          { logicalId: 'ExpensiveResource', type: 'AWS::SNS::Topic', unitPrice: 0.00005, unit: 'Requests', currency: 'USD' },
+          { logicalId: 'MidResource', type: 'AWS::Lambda::Function', unitPrice: 0.000002, unit: 'Requests', currency: 'USD' },
+        ],
+      });
+      const result = formatTable([stack], true);
+      const expensivePos = result.indexOf('ExpensiveResource');
+      const midPos = result.indexOf('MidResource');
+      const cheapPos = result.indexOf('CheapResource');
+      // Highest unit price first
+      expect(expensivePos).toBeLessThan(midPos);
+      expect(midPos).toBeLessThan(cheapPos);
+    });
+  });
+
+  describe('total line color', () => {
+    it('total line has no ANSI codes when noColor=true', () => {
+      const result = formatTable([makeStack()], true);
+      const totalLine = result.split('\n').find((l) => l.includes('TOTAL ESTIMATED MONTHLY COST'));
+      expect(totalLine).toBeDefined();
+      expect(totalLine).not.toMatch(/\x1b\[/);
+    });
+
+    it('total line has ANSI codes (bold green) when noColor=false', () => {
+      const result = formatTable([makeStack()], false);
+      const totalLine = result.split('\n').find((l) => l.replace(/\x1b\[[0-9;]*m/g, '').includes('TOTAL ESTIMATED MONTHLY COST'));
+      expect(totalLine).toBeDefined();
+      expect(totalLine).toMatch(/\x1b\[/);
     });
   });
 


### PR DESCRIPTION


- Add chalk.red to StackPriceError and unknown error messages in parser (breakdown + diff); chalk.level = 0 when --no-color is passed
- Add chalk.yellow to region fallback warning in region.ts
- Strip 8-char CDK hash suffix from logicalId in all table columns (display only; full ID preserved in JSON output)
- Sort usage-based resources by unitPrice descending before rendering
- Color total line bold green (chalk.bold.green)
- Update parser and table tests to match new output format