### PR TITLE
feat: implement stackprice generate usage-file command

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -4,6 +4,14 @@ import * as path from 'path';
 import { Command } from 'commander';
 import chalk from 'chalk';
 
+import {
+  discoverUsageResources,
+  generateYaml,
+  generateJson,
+  writeGeneratedFile,
+  TYPE_MAP,
+} from '../generate/usage-file-generator.js';
+
 import { checkCredentials } from '../pricing/credentials.js';
 import { readAssembly } from '../assembly/reader.js';
 import { parseStacks } from '../template/parser.js';
@@ -28,7 +36,7 @@ import { elasticacheHandler } from '../registry/handlers/elasticache.js';
 import { apigatewayHandler } from '../registry/handlers/apigateway.js';
 import { secretsManagerHandler } from '../registry/handlers/secretsmanager.js';
 import { eksHandler } from '../registry/handlers/eks.js';
-import { StackPriceError } from '../errors/index.js';
+import { EXIT_CODES, StackPriceError } from '../errors/index.js';
 import packageJson from '../../package.json';
 
 // ─── Commander option shapes ──────────────────────────────────────────────────
@@ -296,6 +304,112 @@ export function createProgram(): Command {
         } else {
           process.stdout.write(formatted + '\n');
         }
+      } catch (err: unknown) {
+        if (err instanceof StackPriceError) {
+          process.stderr.write(chalk.red(`✗ ${err.message}\n`));
+          process.exit(err.exitCode);
+        } else {
+          process.stderr.write(chalk.red(`An unexpected error occurred.\n`));
+          process.exit(2);
+        }
+      }
+    });
+
+  // ── generate ───────────────────────────────────────────────────────────────
+
+  const generateCmd = program
+    .command('generate')
+    .description('Generate files from a CDK cloud assembly');
+
+  generateCmd
+    .command('usage-file')
+    .description('Generate a pre-populated usage estimates file for usage-based resources')
+    .option('--dir <path>', 'Path to CDK cloud assembly directory', 'cdk.out')
+    .option('--stack <name>', 'Filter to a specific stack name (optional)')
+    .option('--format <format>', 'Output format: yaml or json', 'yaml')
+    .option('--out-file <path>', 'Output file path (default depends on --format)')
+    .option('--force', 'Overwrite existing output file', false)
+    .option('--types <list>', 'Comma-separated resource types to include (e.g. Lambda,S3)')
+    .option('--no-color', 'Disable colour output')
+    .action((options: {
+      dir: string;
+      stack?: string;
+      format: string;
+      outFile?: string;
+      force: boolean;
+      types?: string;
+      color: boolean;
+    }) => {
+      chalk.level = options.color ? 3 : 0;
+
+      try {
+        // ── Validate --format ──────────────────────────────────────────────────
+        if (options.format !== 'yaml' && options.format !== 'json') {
+          throw new StackPriceError(
+            `Invalid format "${options.format}". Must be yaml or json.`,
+            EXIT_CODES.FAILURE,
+          );
+        }
+
+        const format = options.format as 'yaml' | 'json';
+
+        // ── Resolve default outFile ────────────────────────────────────────────
+        const outFile = options.outFile ?? (format === 'json' ? 'stackprice-usage.json' : 'stackprice-usage.yml');
+
+        // ── Validate --types ───────────────────────────────────────────────────
+        const validShortNames = Object.keys(TYPE_MAP);
+        let typeFilter: string[] = [];
+
+        if (options.types !== undefined) {
+          typeFilter = options.types.split(',').map((t) => t.trim()).filter((t) => t.length > 0);
+          for (const t of typeFilter) {
+            if (!Object.prototype.hasOwnProperty.call(TYPE_MAP, t)) {
+              throw new StackPriceError(
+                `Unknown resource type '${t}'. Valid types: ${validShortNames.join(', ')}`,
+                EXIT_CODES.FAILURE,
+              );
+            }
+          }
+        }
+
+        // ── Discover resources ─────────────────────────────────────────────────
+        const resources = discoverUsageResources(options.dir, options.stack, typeFilter.length > 0 ? typeFilter : undefined);
+
+        if (resources.length === 0) {
+          process.stderr.write(`Warning: No usage-based resources found in ${options.dir}.\n`);
+        }
+
+        // ── Generate content ───────────────────────────────────────────────────
+        const generateOptions = {
+          dir: options.dir,
+          stack: options.stack,
+          format,
+          outFile,
+          force: options.force,
+          types: typeFilter,
+        };
+
+        const content = format === 'json'
+          ? generateJson(resources, generateOptions)
+          : generateYaml(resources, generateOptions);
+
+        // ── Write file ─────────────────────────────────────────────────────────
+        writeGeneratedFile(content, outFile, options.force);
+
+        // ── Print confirmation ─────────────────────────────────────────────────
+        const typeCounts = new Map<string, number>();
+        for (const r of resources) {
+          typeCounts.set(r.type, (typeCounts.get(r.type) ?? 0) + 1);
+        }
+
+        process.stdout.write(`Generated ${outFile} with ${resources.length} usage-based resources:\n`);
+        for (const [cfnType, count] of typeCounts) {
+          process.stdout.write(`  ${count} × ${cfnType}\n`);
+        }
+        process.stdout.write(`\nEdit the TODO values, then run:\n`);
+        process.stdout.write(`  stackprice breakdown --dir ${options.dir} --usage-file ${outFile}\n`);
+        process.stdout.write(`\nNote: Generated without AWS credentials.\n`);
+
       } catch (err: unknown) {
         if (err instanceof StackPriceError) {
           process.stderr.write(chalk.red(`✗ ${err.message}\n`));

--- a/src/generate/usage-file-generator.ts
+++ b/src/generate/usage-file-generator.ts
@@ -1,0 +1,490 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { EXIT_CODES, StackPriceError } from '../errors/index.js';
+import { readAssembly } from '../assembly/reader.js';
+
+// ─── Type map (short name → CloudFormation type) ──────────────────────────────
+
+export const TYPE_MAP: Record<string, string> = {
+  Lambda:     'AWS::Lambda::Function',
+  S3:         'AWS::S3::Bucket',
+  SQS:        'AWS::SQS::Queue',
+  SNS:        'AWS::SNS::Topic',
+  ApiGateway: 'AWS::ApiGateway::RestApi',
+  NatGateway: 'AWS::EC2::NatGateway',
+  CloudFront: 'AWS::CloudFront::Distribution',
+};
+
+// Handlers registered as isUsageBased: true in the registry
+const REGISTERED_USAGE_BASED_TYPES = new Set([
+  'AWS::Lambda::Function',
+  'AWS::S3::Bucket',
+  'AWS::SQS::Queue',
+  'AWS::SNS::Topic',
+  'AWS::ApiGateway::RestApi',
+]);
+
+// Not yet registered but planned for v0.5.0 — include anyway for future-proofing
+const UPCOMING_USAGE_BASED_TYPES = new Set([
+  'AWS::EC2::NatGateway',
+  'AWS::CloudFront::Distribution',
+]);
+
+const ALL_USAGE_BASED_TYPES = new Set([
+  ...REGISTERED_USAGE_BASED_TYPES,
+  ...UPCOMING_USAGE_BASED_TYPES,
+]);
+
+// Canonical output order for grouped YAML/JSON sections
+const TYPE_ORDER = [
+  'AWS::Lambda::Function',
+  'AWS::S3::Bucket',
+  'AWS::SQS::Queue',
+  'AWS::SNS::Topic',
+  'AWS::ApiGateway::RestApi',
+  'AWS::EC2::NatGateway',
+  'AWS::CloudFront::Distribution',
+];
+
+// ─── Exported interfaces ──────────────────────────────────────────────────────
+
+export interface GenerateOptions {
+  dir: string;
+  stack?: string;
+  format: 'yaml' | 'json';
+  outFile: string;
+  force: boolean;
+  types: string[];
+}
+
+export interface UsageResource {
+  logicalId: string;
+  type: string;
+  stackId: string;
+  properties: Record<string, unknown>;
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+function readTemplateResources(
+  templatePath: string,
+): Array<{ logicalId: string; type: string; properties: Record<string, unknown> }> {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(templatePath, 'utf-8') as string;
+  } catch {
+    throw new StackPriceError(
+      `Cannot read template file: ${path.basename(templatePath)}`,
+      EXIT_CODES.FAILURE,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new StackPriceError(
+      `Template is not valid JSON: ${path.basename(templatePath)}`,
+      EXIT_CODES.FAILURE,
+    );
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return [];
+  }
+
+  const templateObj = parsed as Record<string, unknown>;
+  const rawResources = Object.prototype.hasOwnProperty.call(templateObj, 'Resources')
+    ? templateObj['Resources']
+    : undefined;
+
+  if (
+    typeof rawResources !== 'object' ||
+    rawResources === null ||
+    Array.isArray(rawResources)
+  ) {
+    return [];
+  }
+
+  const resourcesObj = rawResources as Record<string, unknown>;
+  const resources: Array<{ logicalId: string; type: string; properties: Record<string, unknown> }> = [];
+
+  for (const logicalId of Object.keys(resourcesObj)) {
+    const entry: unknown = resourcesObj[logicalId];
+    if (typeof entry !== 'object' || entry === null) continue;
+
+    const entryObj = entry as Record<string, unknown>;
+    const type = Object.prototype.hasOwnProperty.call(entryObj, 'Type')
+      ? entryObj['Type']
+      : undefined;
+    if (typeof type !== 'string') continue;
+
+    const rawProps = Object.prototype.hasOwnProperty.call(entryObj, 'Properties')
+      ? entryObj['Properties']
+      : undefined;
+    const properties: Record<string, unknown> =
+      typeof rawProps === 'object' && rawProps !== null && !Array.isArray(rawProps)
+        ? (rawProps as Record<string, unknown>)
+        : {};
+
+    resources.push({ logicalId, type, properties });
+  }
+
+  return resources;
+}
+
+// ─── YAML generation helpers ──────────────────────────────────────────────────
+
+// Pad key-value string to column 31, then append `# comment`
+function commentLine(keyValue: string, comment: string): string {
+  return `${keyValue.padEnd(31)}# ${comment}`;
+}
+
+// Build a 56-char wide type separator using box-drawing characters
+function typeSeparator(type: string): string {
+  const prefix = `# ── ${type} `;
+  const remaining = Math.max(0, 56 - prefix.length);
+  return prefix + '─'.repeat(remaining);
+}
+
+function lambdaYamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { properties, logicalId } = resource;
+
+  const commentParts: string[] = [];
+
+  const funcName = properties['FunctionName'];
+  if (typeof funcName === 'string') {
+    commentParts.push(`Name: ${funcName}`);
+  }
+  const runtime = properties['Runtime'];
+  if (typeof runtime === 'string') {
+    commentParts.push(`Runtime: ${runtime}`);
+  }
+  const timeout = properties['Timeout'];
+  const timeoutS = typeof timeout === 'number' ? timeout : undefined;
+  if (timeoutS !== undefined) {
+    commentParts.push(`Timeout: ${timeoutS}s`);
+  }
+
+  if (commentParts.length > 0) {
+    lines.push(`# ${commentParts.join(' | ')}`);
+  }
+
+  lines.push(`${logicalId}:`);
+  lines.push(commentLine('  requests_per_month: 0', 'TODO: monthly invocations'));
+
+  const maxMs = timeoutS !== undefined ? ` (max: ${timeoutS * 1000}ms)` : '';
+  lines.push(commentLine('  avg_duration_ms: 0', `TODO: average execution time in ms${maxMs}`));
+
+  const memorySize = properties['MemorySize'];
+  const memoryMb = typeof memorySize === 'number' ? memorySize : 128;
+  lines.push(commentLine(`  memory_mb: ${memoryMb}`, 'pre-filled from CDK template'));
+
+  return lines;
+}
+
+function s3YamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { properties, logicalId } = resource;
+
+  const bucketName = properties['BucketName'];
+  if (typeof bucketName === 'string') {
+    lines.push(`# Name: ${bucketName}`);
+  }
+
+  lines.push(`${logicalId}:`);
+  lines.push(commentLine('  storage_gb: 0', 'TODO: average GB stored per month'));
+
+  return lines;
+}
+
+function sqsYamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { properties, logicalId } = resource;
+
+  const isFifo = properties['FifoQueue'] === true;
+  lines.push(`# Queue type: ${isFifo ? 'FIFO' : 'Standard'}`);
+
+  lines.push(`${logicalId}:`);
+  lines.push(commentLine('  requests_per_month: 0', 'TODO: monthly messages'));
+
+  return lines;
+}
+
+function snsYamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { properties, logicalId } = resource;
+
+  const topicName = properties['TopicName'];
+  if (typeof topicName === 'string') {
+    lines.push(`# Name: ${topicName}`);
+  }
+
+  lines.push(`${logicalId}:`);
+  lines.push(commentLine('  requests_per_month: 0', 'TODO: monthly notifications'));
+
+  return lines;
+}
+
+function apigatewayYamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { properties, logicalId } = resource;
+
+  const name = properties['Name'];
+  if (typeof name === 'string') {
+    lines.push(`# Name: ${name}`);
+  }
+
+  lines.push(`${logicalId}:`);
+  lines.push(commentLine('  requests_per_month: 0', 'TODO: monthly API calls'));
+
+  return lines;
+}
+
+function natgatewayYamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { logicalId } = resource;
+
+  lines.push('# Fixed hourly cost ($32.85/month) included automatically');
+  lines.push(`${logicalId}:`);
+  lines.push(commentLine('  data_transfer_gb: 0', 'TODO: monthly GB processed'));
+
+  return lines;
+}
+
+function cloudfrontYamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { logicalId } = resource;
+
+  lines.push('# Prices shown for US edge locations. Actual costs vary by zone.');
+  lines.push(`${logicalId}:`);
+  lines.push(commentLine('  monthly_requests: 0', 'TODO: monthly HTTP/HTTPS requests'));
+  lines.push(commentLine('  monthly_transfer_gb: 0', 'TODO: monthly GB transferred to users'));
+
+  return lines;
+}
+
+function generateYamlEntry(resource: UsageResource): string[] {
+  switch (resource.type) {
+    case 'AWS::Lambda::Function':         return lambdaYamlEntry(resource);
+    case 'AWS::S3::Bucket':               return s3YamlEntry(resource);
+    case 'AWS::SQS::Queue':               return sqsYamlEntry(resource);
+    case 'AWS::SNS::Topic':               return snsYamlEntry(resource);
+    case 'AWS::ApiGateway::RestApi':      return apigatewayYamlEntry(resource);
+    case 'AWS::EC2::NatGateway':          return natgatewayYamlEntry(resource);
+    case 'AWS::CloudFront::Distribution': return cloudfrontYamlEntry(resource);
+    default:                              return [];
+  }
+}
+
+// ─── JSON entry builders ──────────────────────────────────────────────────────
+
+function buildJsonEntry(resource: UsageResource): Record<string, unknown> {
+  const entry: Record<string, unknown> = { _type: resource.type };
+  const p = resource.properties;
+
+  switch (resource.type) {
+    case 'AWS::Lambda::Function': {
+      const runtime = p['Runtime'];
+      if (typeof runtime === 'string') entry['_runtime'] = runtime;
+      const timeout = p['Timeout'];
+      if (typeof timeout === 'number') entry['_timeout_ms'] = timeout * 1000;
+      const memorySize = p['MemorySize'];
+      entry['requests_per_month'] = 0;
+      entry['avg_duration_ms'] = 0;
+      entry['memory_mb'] = typeof memorySize === 'number' ? memorySize : 128;
+      break;
+    }
+    case 'AWS::S3::Bucket': {
+      entry['storage_gb'] = 0;
+      break;
+    }
+    case 'AWS::SQS::Queue': {
+      entry['_queue_type'] = p['FifoQueue'] === true ? 'FIFO' : 'Standard';
+      entry['requests_per_month'] = 0;
+      break;
+    }
+    case 'AWS::SNS::Topic': {
+      entry['requests_per_month'] = 0;
+      break;
+    }
+    case 'AWS::ApiGateway::RestApi': {
+      const name = p['Name'];
+      if (typeof name === 'string') entry['_name'] = name;
+      entry['requests_per_month'] = 0;
+      break;
+    }
+    case 'AWS::EC2::NatGateway': {
+      entry['_note'] = 'Fixed hourly cost ($32.85/month) included automatically';
+      entry['data_transfer_gb'] = 0;
+      break;
+    }
+    case 'AWS::CloudFront::Distribution': {
+      entry['_note'] = 'Prices shown for US edge locations. Actual costs vary by geographic zone.';
+      entry['monthly_requests'] = 0;
+      entry['monthly_transfer_gb'] = 0;
+      break;
+    }
+    default:
+      break;
+  }
+
+  return entry;
+}
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+export function discoverUsageResources(
+  dir: string,
+  stackFilter?: string,
+  typeFilter?: string[],
+): UsageResource[] {
+  const resolvedDir = path.resolve(dir);
+
+  // readAssembly handles directory-not-found and invalid-assembly errors
+  const assembly = readAssembly(resolvedDir);
+
+  if (stackFilter !== undefined) {
+    const found = assembly.stacks.some((s) => s.id === stackFilter);
+    if (!found) {
+      throw new StackPriceError(
+        `Stack '${stackFilter}' not found in ${dir}.`,
+        EXIT_CODES.FAILURE,
+      );
+    }
+  }
+
+  // Build the set of CFN types to include
+  const includedCfnTypes = new Set<string>();
+  if (typeFilter === undefined || typeFilter.length === 0) {
+    for (const t of ALL_USAGE_BASED_TYPES) {
+      includedCfnTypes.add(t);
+    }
+  } else {
+    for (const shortName of typeFilter) {
+      const cfnType = TYPE_MAP[shortName];
+      if (cfnType !== undefined && ALL_USAGE_BASED_TYPES.has(cfnType)) {
+        includedCfnTypes.add(cfnType);
+      }
+    }
+  }
+
+  const resources: UsageResource[] = [];
+
+  for (const stackManifest of assembly.stacks) {
+    if (stackFilter !== undefined && stackManifest.id !== stackFilter) continue;
+
+    const templatePath = path.resolve(path.join(resolvedDir, stackManifest.templateFile));
+    const templateResources = readTemplateResources(templatePath);
+
+    for (const r of templateResources) {
+      if (includedCfnTypes.has(r.type)) {
+        resources.push({
+          logicalId: r.logicalId,
+          type: r.type,
+          stackId: stackManifest.id,
+          properties: r.properties,
+        });
+      }
+    }
+  }
+
+  return resources;
+}
+
+export function generateYaml(resources: UsageResource[], options: GenerateOptions): string {
+  const stackDesc = options.stack !== undefined ? options.stack : 'all stacks';
+  const lines: string[] = [
+    '# stackprice usage estimates',
+    `# Generated from: ${options.dir} (${stackDesc})`,
+    '# Edit the TODO values, then run:',
+    `#   stackprice breakdown --dir ${options.dir} --usage-file ${options.outFile}`,
+    '#',
+    '# Resources with 0 values are excluded from cost estimates.',
+    '# This file was generated without AWS credentials.',
+  ];
+
+  if (resources.length === 0) {
+    return lines.join('\n') + '\n';
+  }
+
+  // Group by type preserving TYPE_ORDER
+  const byType = new Map<string, UsageResource[]>();
+  for (const type of TYPE_ORDER) {
+    byType.set(type, []);
+  }
+  for (const resource of resources) {
+    const group = byType.get(resource.type);
+    if (group !== undefined) {
+      group.push(resource);
+    }
+  }
+
+  for (const type of TYPE_ORDER) {
+    const group = byType.get(type) ?? [];
+    if (group.length === 0) continue;
+
+    // Sort alphabetically by logicalId within each group
+    const sorted = [...group].sort((a, b) => a.logicalId.localeCompare(b.logicalId));
+
+    lines.push('');
+    lines.push(typeSeparator(type));
+    for (const resource of sorted) {
+      lines.push(...generateYamlEntry(resource));
+    }
+  }
+
+  return lines.join('\n') + '\n';
+}
+
+export function generateJson(resources: UsageResource[], options: GenerateOptions): string {
+  const result: Record<string, unknown> = {
+    _generated: 'stackprice generate usage-file',
+    _source: options.dir,
+    _instructions: `Edit the 0 values, then run: stackprice breakdown --dir ${options.dir} --usage-file ${options.outFile}`,
+  };
+
+  // Output in TYPE_ORDER for consistent ordering
+  const byType = new Map<string, UsageResource[]>();
+  for (const type of TYPE_ORDER) {
+    byType.set(type, []);
+  }
+  for (const resource of resources) {
+    const group = byType.get(resource.type);
+    if (group !== undefined) {
+      group.push(resource);
+    }
+  }
+
+  for (const type of TYPE_ORDER) {
+    const group = byType.get(type) ?? [];
+    const sorted = [...group].sort((a, b) => a.logicalId.localeCompare(b.logicalId));
+    for (const resource of sorted) {
+      result[resource.logicalId] = buildJsonEntry(resource);
+    }
+  }
+
+  return JSON.stringify(result, null, 2);
+}
+
+export function writeGeneratedFile(content: string, outFile: string, force: boolean): void {
+  const resolved = path.resolve(outFile);
+
+  if (!force && fs.existsSync(resolved)) {
+    throw new StackPriceError(
+      `${outFile} already exists. Use --force to overwrite.`,
+      EXIT_CODES.FAILURE,
+    );
+  }
+
+  try {
+    fs.writeFileSync(resolved, content, 'utf-8');
+  } catch {
+    throw new StackPriceError(
+      `Failed to write output file: ${outFile}`,
+      EXIT_CODES.FAILURE,
+    );
+  }
+}

--- a/tests/unit/cli/parser.test.ts
+++ b/tests/unit/cli/parser.test.ts
@@ -83,6 +83,27 @@ vi.mock('../../../src/output/diff.js', () => ({
   formatDiffSummary: (...args: unknown[]): unknown => mockFormatDiffSummary(...args),
 }));
 
+const mockDiscoverUsageResources = vi.fn();
+const mockGenerateYaml = vi.fn();
+const mockGenerateJson = vi.fn();
+const mockWriteGeneratedFile = vi.fn();
+
+vi.mock('../../../src/generate/usage-file-generator.js', () => ({
+  discoverUsageResources: (...args: unknown[]): unknown => mockDiscoverUsageResources(...args),
+  generateYaml: (...args: unknown[]): unknown => mockGenerateYaml(...args),
+  generateJson: (...args: unknown[]): unknown => mockGenerateJson(...args),
+  writeGeneratedFile: (...args: unknown[]): unknown => mockWriteGeneratedFile(...args),
+  TYPE_MAP: {
+    Lambda: 'AWS::Lambda::Function',
+    S3: 'AWS::S3::Bucket',
+    SQS: 'AWS::SQS::Queue',
+    SNS: 'AWS::SNS::Topic',
+    ApiGateway: 'AWS::ApiGateway::RestApi',
+    NatGateway: 'AWS::EC2::NatGateway',
+    CloudFront: 'AWS::CloudFront::Distribution',
+  },
+}));
+
 import { createProgram } from '../../../src/cli/parser.js';
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -643,5 +664,158 @@ describe('createProgram — diff command', () => {
       expect.stringContaining('Use --verbose'),
     );
     expect(mockExit).toHaveBeenCalledWith(2);
+  });
+});
+
+// ─── generate usage-file command ──────────────────────────────────────────────
+
+describe('createProgram — generate usage-file command', () => {
+  let mockExit: ReturnType<typeof vi.spyOn>;
+  let mockStderr: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockExit = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+    vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    mockStderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    mockDiscoverUsageResources.mockReturnValue([]);
+    mockGenerateYaml.mockReturnValue('# yaml output\n');
+    mockGenerateJson.mockReturnValue('{}');
+    mockWriteGeneratedFile.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('discoverUsageResources called with correct dir and stack args', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'generate', 'usage-file',
+      '--dir', '/fake/cdk.out',
+      '--stack', 'MyStack',
+    ]);
+
+    expect(mockDiscoverUsageResources).toHaveBeenCalledWith(
+      '/fake/cdk.out',
+      'MyStack',
+      undefined,
+    );
+  });
+
+  it('--format json sets stackprice-usage.json as default outFile', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'generate', 'usage-file',
+      '--format', 'json',
+    ]);
+
+    expect(mockGenerateJson).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ outFile: 'stackprice-usage.json' }),
+    );
+    expect(mockWriteGeneratedFile).toHaveBeenCalledWith(
+      expect.any(String),
+      'stackprice-usage.json',
+      false,
+    );
+  });
+
+  it('default format yaml sets stackprice-usage.yml as default outFile', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'generate', 'usage-file']);
+
+    expect(mockGenerateYaml).toHaveBeenCalledWith(
+      expect.any(Array),
+      expect.objectContaining({ outFile: 'stackprice-usage.yml' }),
+    );
+    expect(mockWriteGeneratedFile).toHaveBeenCalledWith(
+      expect.any(String),
+      'stackprice-usage.yml',
+      false,
+    );
+  });
+
+  it('invalid --types value exits with error', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'generate', 'usage-file',
+      '--types', 'Lambda,INVALID',
+    ]);
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('Unknown resource type'));
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('INVALID'));
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it('valid --types passes filtered array to discoverUsageResources', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'generate', 'usage-file',
+      '--types', 'Lambda,S3',
+    ]);
+
+    expect(mockDiscoverUsageResources).toHaveBeenCalledWith(
+      expect.any(String),
+      undefined,
+      ['Lambda', 'S3'],
+    );
+  });
+
+  it('--force passed as true to writeGeneratedFile', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'generate', 'usage-file',
+      '--force',
+    ]);
+
+    expect(mockWriteGeneratedFile).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(String),
+      true,
+    );
+  });
+
+  it('--stack passed to discoverUsageResources', async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      'node', 'stackprice', 'generate', 'usage-file',
+      '--stack', 'TargetStack',
+    ]);
+
+    expect(mockDiscoverUsageResources).toHaveBeenCalledWith(
+      expect.any(String),
+      'TargetStack',
+      undefined,
+    );
+  });
+
+  it('no usage-based resources found prints warning to stderr', async () => {
+    mockDiscoverUsageResources.mockReturnValue([]);
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'generate', 'usage-file']);
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('No usage-based resources found'));
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it('StackPriceError from discoverUsageResources → stderr + exit 2', async () => {
+    const { StackPriceError: SPE } = await import('../../../src/errors/index.js');
+    mockDiscoverUsageResources.mockImplementation(() => {
+      throw new SPE('Stack not found', 2);
+    });
+
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'generate', 'usage-file']);
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining('Stack not found'));
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it('does NOT call checkCredentials', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'stackprice', 'generate', 'usage-file']);
+
+    expect(mockCheckCredentials).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/generate/usage-file-generator.test.ts
+++ b/tests/unit/generate/usage-file-generator.test.ts
@@ -1,0 +1,567 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ─── fs mock ──────────────────────────────────────────────────────────────────
+
+const mockExistsSync = vi.fn();
+const mockWriteFileSync = vi.fn();
+const mockReadFileSync = vi.fn();
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return {
+    ...actual,
+    existsSync: (...args: unknown[]): unknown => mockExistsSync(...args),
+    writeFileSync: (...args: unknown[]): unknown => mockWriteFileSync(...args),
+    readFileSync: (...args: unknown[]): unknown => mockReadFileSync(...args),
+  };
+});
+
+// ─── readAssembly mock ────────────────────────────────────────────────────────
+
+const mockReadAssembly = vi.fn();
+
+vi.mock('../../../src/assembly/reader.js', () => ({
+  readAssembly: (...args: unknown[]): unknown => mockReadAssembly(...args),
+}));
+
+import {
+  discoverUsageResources,
+  generateYaml,
+  generateJson,
+  writeGeneratedFile,
+} from '../../../src/generate/usage-file-generator.js';
+import type { UsageResource, GenerateOptions } from '../../../src/generate/usage-file-generator.js';
+import { StackPriceError } from '../../../src/errors/index.js';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+function makeAssembly(stacks: Array<{ id: string; templateFile: string }>): {
+  version: string;
+  stacks: Array<{ id: string; templateFile: string; environment: { account: string; region: string } }>;
+} {
+  return {
+    version: '17.0.0',
+    stacks: stacks.map((s) => ({
+      id: s.id,
+      templateFile: s.templateFile,
+      environment: { account: '123456789012', region: 'us-east-1' },
+    })),
+  };
+}
+
+function makeTemplate(resources: Record<string, { Type: string; Properties?: Record<string, unknown> }>): string {
+  return JSON.stringify({ Resources: resources });
+}
+
+function makeGenerateOptions(overrides: Partial<GenerateOptions> = {}): GenerateOptions {
+  return {
+    dir: './cdk.out',
+    format: 'yaml',
+    outFile: 'stackprice-usage.yml',
+    force: false,
+    types: [],
+    ...overrides,
+  };
+}
+
+function makeLambdaResource(logicalId: string, props: Record<string, unknown> = {}): UsageResource {
+  return {
+    logicalId,
+    type: 'AWS::Lambda::Function',
+    stackId: 'MyStack',
+    properties: { Runtime: 'nodejs20.x', MemorySize: 128, Timeout: 3, ...props },
+  };
+}
+
+function makeS3Resource(logicalId: string, props: Record<string, unknown> = {}): UsageResource {
+  return {
+    logicalId,
+    type: 'AWS::S3::Bucket',
+    stackId: 'MyStack',
+    properties: { ...props },
+  };
+}
+
+function makeSqsResource(logicalId: string, props: Record<string, unknown> = {}): UsageResource {
+  return {
+    logicalId,
+    type: 'AWS::SQS::Queue',
+    stackId: 'MyStack',
+    properties: { ...props },
+  };
+}
+
+function makeSnsResource(logicalId: string, props: Record<string, unknown> = {}): UsageResource {
+  return {
+    logicalId,
+    type: 'AWS::SNS::Topic',
+    stackId: 'MyStack',
+    properties: { ...props },
+  };
+}
+
+function makeApiGatewayResource(logicalId: string, props: Record<string, unknown> = {}): UsageResource {
+  return {
+    logicalId,
+    type: 'AWS::ApiGateway::RestApi',
+    stackId: 'MyStack',
+    properties: { ...props },
+  };
+}
+
+function makeNatGatewayResource(logicalId: string): UsageResource {
+  return {
+    logicalId,
+    type: 'AWS::EC2::NatGateway',
+    stackId: 'MyStack',
+    properties: {},
+  };
+}
+
+function makeCloudFrontResource(logicalId: string): UsageResource {
+  return {
+    logicalId,
+    type: 'AWS::CloudFront::Distribution',
+    stackId: 'MyStack',
+    properties: {},
+  };
+}
+
+// ─── discoverUsageResources ───────────────────────────────────────────────────
+
+describe('discoverUsageResources', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns Lambda, S3, SQS, SNS, ApiGateway resources from a template', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([{ id: 'MyStack', templateFile: 'MyStack.template.json' }]));
+    mockReadFileSync.mockReturnValue(makeTemplate({
+      MyLambda: { Type: 'AWS::Lambda::Function', Properties: { Runtime: 'nodejs20.x', MemorySize: 256 } },
+      MyBucket: { Type: 'AWS::S3::Bucket' },
+      MyQueue:  { Type: 'AWS::SQS::Queue' },
+      MyTopic:  { Type: 'AWS::SNS::Topic' },
+      MyApi:    { Type: 'AWS::ApiGateway::RestApi' },
+      MyEC2:    { Type: 'AWS::EC2::Instance' },
+    }));
+
+    const resources = discoverUsageResources('./cdk.out');
+
+    expect(resources).toHaveLength(5);
+    const types = resources.map((r) => r.type);
+    expect(types).toContain('AWS::Lambda::Function');
+    expect(types).toContain('AWS::S3::Bucket');
+    expect(types).toContain('AWS::SQS::Queue');
+    expect(types).toContain('AWS::SNS::Topic');
+    expect(types).toContain('AWS::ApiGateway::RestApi');
+    expect(types).not.toContain('AWS::EC2::Instance');
+  });
+
+  it('returns NatGateway and CloudFront resources when present', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([{ id: 'MyStack', templateFile: 'MyStack.template.json' }]));
+    mockReadFileSync.mockReturnValue(makeTemplate({
+      MyNat:    { Type: 'AWS::EC2::NatGateway' },
+      MyCF:     { Type: 'AWS::CloudFront::Distribution' },
+    }));
+
+    const resources = discoverUsageResources('./cdk.out');
+
+    expect(resources).toHaveLength(2);
+    expect(resources.map((r) => r.type)).toContain('AWS::EC2::NatGateway');
+    expect(resources.map((r) => r.type)).toContain('AWS::CloudFront::Distribution');
+  });
+
+  it('filters by stack name correctly', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([
+      { id: 'StackA', templateFile: 'StackA.template.json' },
+      { id: 'StackB', templateFile: 'StackB.template.json' },
+    ]));
+    mockReadFileSync
+      .mockReturnValueOnce(makeTemplate({ LambdaA: { Type: 'AWS::Lambda::Function' } }))
+      .mockReturnValueOnce(makeTemplate({ LambdaB: { Type: 'AWS::Lambda::Function' } }));
+
+    const resources = discoverUsageResources('./cdk.out', 'StackA');
+
+    expect(resources).toHaveLength(1);
+    expect(resources[0]!.stackId).toBe('StackA');
+    expect(resources[0]!.logicalId).toBe('LambdaA');
+  });
+
+  it('filters by type short name correctly', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([{ id: 'MyStack', templateFile: 'MyStack.template.json' }]));
+    mockReadFileSync.mockReturnValue(makeTemplate({
+      MyLambda: { Type: 'AWS::Lambda::Function' },
+      MyBucket: { Type: 'AWS::S3::Bucket' },
+    }));
+
+    const resources = discoverUsageResources('./cdk.out', undefined, ['Lambda']);
+
+    expect(resources).toHaveLength(1);
+    expect(resources[0]!.type).toBe('AWS::Lambda::Function');
+  });
+
+  it('returns empty array when no usage-based resources found', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([{ id: 'MyStack', templateFile: 'MyStack.template.json' }]));
+    mockReadFileSync.mockReturnValue(makeTemplate({
+      MyEC2: { Type: 'AWS::EC2::Instance' },
+      MyRDS: { Type: 'AWS::RDS::DBInstance' },
+    }));
+
+    const resources = discoverUsageResources('./cdk.out');
+
+    expect(resources).toHaveLength(0);
+  });
+
+  it('throws StackPriceError for missing directory', () => {
+    mockReadAssembly.mockImplementation(() => {
+      throw new StackPriceError('Directory not found: /missing', 2);
+    });
+
+    expect(() => discoverUsageResources('/missing')).toThrow(StackPriceError);
+  });
+
+  it('throws StackPriceError for invalid CDK assembly', () => {
+    mockReadAssembly.mockImplementation(() => {
+      throw new StackPriceError('Not a valid CDK cloud assembly', 2);
+    });
+
+    expect(() => discoverUsageResources('./not-a-cdk-out')).toThrow(StackPriceError);
+  });
+
+  it('throws StackPriceError for unknown stack name', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([{ id: 'ExistingStack', templateFile: 'ExistingStack.template.json' }]));
+
+    expect(() => discoverUsageResources('./cdk.out', 'NonExistentStack')).toThrow(StackPriceError);
+    expect(() => discoverUsageResources('./cdk.out', 'NonExistentStack')).toThrowError(/NonExistentStack/);
+  });
+
+  it('throws StackPriceError when template file cannot be read', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([{ id: 'MyStack', templateFile: 'MyStack.template.json' }]));
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT: no such file');
+    });
+
+    expect(() => discoverUsageResources('./cdk.out')).toThrow(StackPriceError);
+  });
+
+  it('handles resources with no Properties block gracefully', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([{ id: 'MyStack', templateFile: 'MyStack.template.json' }]));
+    mockReadFileSync.mockReturnValue(JSON.stringify({
+      Resources: {
+        BareFunc: { Type: 'AWS::Lambda::Function' },
+      },
+    }));
+
+    const resources = discoverUsageResources('./cdk.out');
+
+    expect(resources).toHaveLength(1);
+    expect(resources[0]!.logicalId).toBe('BareFunc');
+    expect(resources[0]!.properties).toEqual({});
+  });
+
+  it('returns empty array for template with no Resources block', () => {
+    mockReadAssembly.mockReturnValue(makeAssembly([{ id: 'MyStack', templateFile: 'MyStack.template.json' }]));
+    mockReadFileSync.mockReturnValue(JSON.stringify({ AWSTemplateFormatVersion: '2010-09-09' }));
+
+    const resources = discoverUsageResources('./cdk.out');
+
+    expect(resources).toHaveLength(0);
+  });
+});
+
+// ─── generateYaml ─────────────────────────────────────────────────────────────
+
+describe('generateYaml', () => {
+  it('Lambda: pre-filled memory_mb from template', () => {
+    const resources = [makeLambdaResource('MyFunc', { MemorySize: 512 })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('memory_mb: 512');
+  });
+
+  it('Lambda: default memory_mb 128 when MemorySize absent', () => {
+    const resources = [makeLambdaResource('MyFunc', { MemorySize: undefined })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('memory_mb: 128');
+  });
+
+  it('Lambda: timeout hint in comment (seconds to ms)', () => {
+    const resources = [makeLambdaResource('MyFunc', { Timeout: 30 })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('max: 30000ms');
+  });
+
+  it('Lambda: runtime in comment', () => {
+    const resources = [makeLambdaResource('MyFunc', { Runtime: 'python3.12' })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('Runtime: python3.12');
+  });
+
+  it('Lambda: FunctionName used as label if present', () => {
+    const resources = [makeLambdaResource('MyFunc', { FunctionName: 'my-api-handler' })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('Name: my-api-handler');
+  });
+
+  it('S3: storage_gb: 0 with comment', () => {
+    const resources = [makeS3Resource('MyBucket')];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('storage_gb: 0');
+    expect(yaml).toContain('# TODO: average GB stored per month');
+  });
+
+  it('S3: BucketName added as label comment if present', () => {
+    const resources = [makeS3Resource('MyBucket', { BucketName: 'my-data-bucket' })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('# Name: my-data-bucket');
+  });
+
+  it('SQS: Standard queue type comment', () => {
+    const resources = [makeSqsResource('MyQueue')];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('# Queue type: Standard');
+  });
+
+  it('SQS: FIFO queue type comment when FifoQueue=true', () => {
+    const resources = [makeSqsResource('MyFifoQueue', { FifoQueue: true })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('# Queue type: FIFO');
+  });
+
+  it('ApiGateway: Name in comment if present', () => {
+    const resources = [makeApiGatewayResource('MyApi', { Name: 'MyService' })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('# Name: MyService');
+  });
+
+  it('NatGateway: fixed cost note in comment', () => {
+    const resources = [makeNatGatewayResource('NatGW')];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('$32.85/month');
+    expect(yaml).toContain('data_transfer_gb: 0');
+  });
+
+  it('CloudFront: geographic zone note in comment', () => {
+    const resources = [makeCloudFrontResource('MyCF')];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('US edge locations');
+    expect(yaml).toContain('monthly_requests: 0');
+    expect(yaml).toContain('monthly_transfer_gb: 0');
+  });
+
+  it('Resources grouped by type with separator comments', () => {
+    const resources = [
+      makeS3Resource('BucketA'),
+      makeLambdaResource('FuncA'),
+    ];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('# ── AWS::Lambda::Function');
+    expect(yaml).toContain('# ── AWS::S3::Bucket');
+  });
+
+  it('Within each group sorted alphabetically by logicalId', () => {
+    const resources = [
+      makeLambdaResource('ZFunc'),
+      makeLambdaResource('AFunc'),
+      makeLambdaResource('MFunc'),
+    ];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    const aPos = yaml.indexOf('AFunc:');
+    const mPos = yaml.indexOf('MFunc:');
+    const zPos = yaml.indexOf('ZFunc:');
+    expect(aPos).toBeLessThan(mPos);
+    expect(mPos).toBeLessThan(zPos);
+  });
+
+  it('Header comment contains dir and outFile path', () => {
+    const resources = [makeLambdaResource('MyFunc')];
+    const yaml = generateYaml(resources, makeGenerateOptions({ dir: './my-cdk', outFile: 'my-usage.yml' }));
+
+    expect(yaml).toContain('./my-cdk');
+    expect(yaml).toContain('my-usage.yml');
+  });
+
+  it('SNS: requests_per_month: 0 with comment', () => {
+    const resources = [makeSnsResource('MyTopic')];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('# ── AWS::SNS::Topic');
+    expect(yaml).toContain('MyTopic:');
+    expect(yaml).toContain('requests_per_month: 0');
+    expect(yaml).toContain('# TODO: monthly notifications');
+  });
+
+  it('SNS: TopicName added as label comment if present', () => {
+    const resources = [makeSnsResource('MyTopic', { TopicName: 'alerts' })];
+    const yaml = generateYaml(resources, makeGenerateOptions());
+
+    expect(yaml).toContain('# Name: alerts');
+  });
+
+  it('No resources: only header comment returned', () => {
+    const yaml = generateYaml([], makeGenerateOptions());
+
+    expect(yaml).toContain('# stackprice usage estimates');
+    expect(yaml).not.toContain('AWS::Lambda::Function');
+    expect(yaml).not.toContain('requests_per_month');
+  });
+});
+
+// ─── generateJson ─────────────────────────────────────────────────────────────
+
+describe('generateJson', () => {
+  it('Lambda: _type, _runtime, _timeout_ms, memory_mb present', () => {
+    const resources = [makeLambdaResource('MyFunc', { Runtime: 'nodejs20.x', Timeout: 30, MemorySize: 512 })];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    const entry = json['MyFunc'] as Record<string, unknown>;
+    expect(entry['_type']).toBe('AWS::Lambda::Function');
+    expect(entry['_runtime']).toBe('nodejs20.x');
+    expect(entry['_timeout_ms']).toBe(30000);
+    expect(entry['memory_mb']).toBe(512);
+    expect(entry['requests_per_month']).toBe(0);
+    expect(entry['avg_duration_ms']).toBe(0);
+  });
+
+  it('SQS: _queue_type present', () => {
+    const resources = [makeSqsResource('MyQueue', { FifoQueue: true })];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    const entry = json['MyQueue'] as Record<string, unknown>;
+    expect(entry['_queue_type']).toBe('FIFO');
+    expect(entry['requests_per_month']).toBe(0);
+  });
+
+  it('SQS: Standard _queue_type when FifoQueue absent', () => {
+    const resources = [makeSqsResource('MyQueue')];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    const entry = json['MyQueue'] as Record<string, unknown>;
+    expect(entry['_queue_type']).toBe('Standard');
+  });
+
+  it('NatGateway: _note about fixed cost present', () => {
+    const resources = [makeNatGatewayResource('NatGW')];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    const entry = json['NatGW'] as Record<string, unknown>;
+    expect(entry['_note']).toContain('$32.85/month');
+    expect(entry['data_transfer_gb']).toBe(0);
+  });
+
+  it('CloudFront: _note about geographic zone present', () => {
+    const resources = [makeCloudFrontResource('MyCF')];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    const entry = json['MyCF'] as Record<string, unknown>;
+    expect(entry['_note']).toContain('geographic zone');
+    expect(entry['monthly_requests']).toBe(0);
+    expect(entry['monthly_transfer_gb']).toBe(0);
+  });
+
+  it('_ prefixed metadata keys present at top level', () => {
+    const resources = [makeS3Resource('MyBucket')];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    expect(json['_generated']).toBe('stackprice generate usage-file');
+    expect(json['_source']).toBeDefined();
+    expect(json['_instructions']).toBeDefined();
+  });
+
+  it('No resources: object with only metadata keys', () => {
+    const json = JSON.parse(generateJson([], makeGenerateOptions())) as Record<string, unknown>;
+
+    const keys = Object.keys(json);
+    expect(keys.every((k) => k.startsWith('_'))).toBe(true);
+    expect(keys).toContain('_generated');
+    expect(keys).toContain('_source');
+    expect(keys).toContain('_instructions');
+  });
+
+  it('SNS: _type and requests_per_month present', () => {
+    const resources = [makeSnsResource('MyTopic')];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    const entry = json['MyTopic'] as Record<string, unknown>;
+    expect(entry['_type']).toBe('AWS::SNS::Topic');
+    expect(entry['requests_per_month']).toBe(0);
+  });
+
+  it('ApiGateway: _name present when Name property set', () => {
+    const resources = [makeApiGatewayResource('MyApi', { Name: 'MyService' })];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    const entry = json['MyApi'] as Record<string, unknown>;
+    expect(entry['_type']).toBe('AWS::ApiGateway::RestApi');
+    expect(entry['_name']).toBe('MyService');
+    expect(entry['requests_per_month']).toBe(0);
+  });
+
+  it('ApiGateway: no _name when Name property absent', () => {
+    const resources = [makeApiGatewayResource('MyApi')];
+    const json = JSON.parse(generateJson(resources, makeGenerateOptions())) as Record<string, unknown>;
+
+    const entry = json['MyApi'] as Record<string, unknown>;
+    expect(entry['_name']).toBeUndefined();
+    expect(entry['requests_per_month']).toBe(0);
+  });
+});
+
+// ─── writeGeneratedFile ───────────────────────────────────────────────────────
+
+describe('writeGeneratedFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes content to the correct path', () => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockReturnValue(undefined);
+
+    writeGeneratedFile('hello', 'stackprice-usage.yml', false);
+
+    expect(mockWriteFileSync).toHaveBeenCalledOnce();
+    const [calledPath, calledContent] = mockWriteFileSync.mock.calls[0] as [string, string, string];
+    expect(calledPath).toContain('stackprice-usage.yml');
+    expect(calledContent).toBe('hello');
+  });
+
+  it('throws StackPriceError if file exists and force=false', () => {
+    mockExistsSync.mockReturnValue(true);
+
+    expect(() => writeGeneratedFile('hello', 'stackprice-usage.yml', false)).toThrow(StackPriceError);
+    expect(() => writeGeneratedFile('hello', 'stackprice-usage.yml', false)).toThrowError(
+      /already exists/,
+    );
+  });
+
+  it('overwrites file if force=true', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockWriteFileSync.mockReturnValue(undefined);
+
+    expect(() => writeGeneratedFile('hello', 'stackprice-usage.yml', true)).not.toThrow();
+    expect(mockWriteFileSync).toHaveBeenCalledOnce();
+  });
+
+  it('throws StackPriceError if writeFileSync throws', () => {
+    mockExistsSync.mockReturnValue(false);
+    mockWriteFileSync.mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    expect(() => writeGeneratedFile('hello', 'stackprice-usage.yml', false)).toThrow(StackPriceError);
+  });
+});


### PR DESCRIPTION
Adds `stackprice generate usage-file` under a new `generate` subcommand. Reads the CDK cloud assembly locally (no AWS credentials required) and emits a pre-populated YAML or JSON usage estimates file for all usage-based resources (Lambda, S3, SQS, SNS, ApiGateway, NatGateway, CloudFront), ready for the user to fill in and pass to `breakdown`.