### PR TITLE
fix: usage file matches both full and stripped logical IDs

### DIFF
--- a/src/output/table.ts
+++ b/src/output/table.ts
@@ -1,6 +1,7 @@
 import Table from 'cli-table3';
 import chalk from 'chalk';
 import type { PricedStack } from '../pricing/types.js';
+import { stripCdkHash } from '../utils/string.js';
 
 function formatCost(amount: number): string {
   return `$${amount.toFixed(2)}`;
@@ -18,19 +19,6 @@ function formatUnitPrice(price: number): string {
 
 function header(label: string, noColor: boolean): string {
   return noColor ? label : chalk.bold(label);
-}
-
-/**
- * Strips the 8-character CDK hash suffix from a logical ID for display.
- * CDK auto-generates suffixes like "99EDD300" (all [0-9A-F], first 4 contain
- * at least one letter A-F). The full logicalId is preserved in JSON output.
- */
-function stripCdkHash(logicalId: string): string {
-  if (logicalId.length <= 8) return logicalId;
-  const suffix = logicalId.slice(-8);
-  if (!/^[0-9A-F]{8}$/.test(suffix)) return logicalId;
-  if (!/[A-F]/.test(suffix.slice(0, 4))) return logicalId;
-  return logicalId.slice(0, -8);
 }
 
 function buildFixedTable(stack: PricedStack, noColor: boolean): string {

--- a/src/pricing/engine.ts
+++ b/src/pricing/engine.ts
@@ -15,6 +15,7 @@ import { fetchPrice } from './client.js';
 import type { ResourceHandler, PricingAttributes, PricingType } from '../registry/handler.js';
 import type { ResourceRecord } from '../template/types.js';
 import { calculateEstimatedCost } from './usage-calculator.js';
+import { stripCdkHash } from '../utils/string.js';
 
 // ─── Internal work item ───────────────────────────────────────────────────────
 
@@ -205,7 +206,7 @@ export async function priceStacks(
           currency: 'USD',
         };
 
-        const usageEntry = usageFile?.[resource.logicalId];
+        const usageEntry = usageFile?.[resource.logicalId] ?? usageFile?.[stripCdkHash(resource.logicalId)];
         if (usageEntry !== undefined) {
           const estimated = calculateEstimatedCost(usageBasedResource, usageEntry);
           if (estimated !== null) {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -1,0 +1,12 @@
+/**
+ * Strips the 8-character CDK hash suffix from a logical ID.
+ * CDK auto-generates suffixes like "99EDD300" (all [0-9A-F], first 4 contain
+ * at least one letter A-F). Returns the original string if no suffix matches.
+ */
+export function stripCdkHash(logicalId: string): string {
+  if (logicalId.length <= 8) return logicalId;
+  const suffix = logicalId.slice(-8);
+  if (!/^[0-9A-F]{8}$/.test(suffix)) return logicalId;
+  if (!/[A-F]/.test(suffix.slice(0, 4))) return logicalId;
+  return logicalId.slice(0, -8);
+}

--- a/tests/unit/pricing/engine.test.ts
+++ b/tests/unit/pricing/engine.test.ts
@@ -727,6 +727,95 @@ describe('priceStacks', () => {
       expect(result!.usageBasedResources).toHaveLength(1);
       expect(result!.estimatedResources).toHaveLength(0);
     });
+
+    it('usageFile match: full logical ID (with CDK hash) works', async () => {
+      const apiResult = makeApiResult(0.0000166667, 'GB-second');
+      mockBuildCacheKey.mockReturnValue('us-east-1:AWSLambda:location=us-east-1');
+      mockFetchPrice.mockResolvedValue(apiResult);
+
+      const estimatedResult = {
+        logicalId: 'MyLambdaABCD1234',
+        type: 'AWS::Lambda::Function',
+        estimatedMonthlyCost: 4.17,
+        currency: 'USD' as const,
+        basis: '5M req × 200ms × 256MB',
+        unitPrice: 0.0000166667,
+        unit: 'GB-second',
+      };
+      mockCalculateEstimatedCost.mockReturnValue(estimatedResult);
+
+      const handler = makeUsageHandler();
+      const stack = makeStack([makeResource('MyLambdaABCD1234', 'AWS::Lambda::Function')]);
+      const registry = makeRegistry(handler);
+
+      const usageFile = { MyLambdaABCD1234: { requests_per_month: 5000000 } };
+      const [result] = await priceStacks([stack], registry, false, usageFile);
+
+      expect(result!.estimatedResources).toHaveLength(1);
+      expect(result!.usageBasedResources).toHaveLength(0);
+    });
+
+    it('usageFile match: stripped logical ID (manually typed) also works', async () => {
+      const apiResult = makeApiResult(0.0000166667, 'GB-second');
+      mockBuildCacheKey.mockReturnValue('us-east-1:AWSLambda:location=us-east-1');
+      mockFetchPrice.mockResolvedValue(apiResult);
+
+      const estimatedResult = {
+        logicalId: 'MyLambdaABCD1234',
+        type: 'AWS::Lambda::Function',
+        estimatedMonthlyCost: 4.17,
+        currency: 'USD' as const,
+        basis: '5M req × 200ms × 256MB',
+        unitPrice: 0.0000166667,
+        unit: 'GB-second',
+      };
+      mockCalculateEstimatedCost.mockReturnValue(estimatedResult);
+
+      const handler = makeUsageHandler();
+      // Resource has full CDK logical ID with hash suffix
+      const stack = makeStack([makeResource('MyLambdaABCD1234', 'AWS::Lambda::Function')]);
+      const registry = makeRegistry(handler);
+
+      // Usage file uses stripped ID (what user sees in the table)
+      const usageFile = { MyLambda: { requests_per_month: 5000000 } };
+      const [result] = await priceStacks([stack], registry, false, usageFile);
+
+      expect(result!.estimatedResources).toHaveLength(1);
+      expect(result!.usageBasedResources).toHaveLength(0);
+    });
+
+    it('usageFile match: full ID takes priority over stripped ID when both exist', async () => {
+      const apiResult = makeApiResult(0.0000166667, 'GB-second');
+      mockBuildCacheKey.mockReturnValue('us-east-1:AWSLambda:location=us-east-1');
+      mockFetchPrice.mockResolvedValue(apiResult);
+
+      const estimatedResult = {
+        logicalId: 'MyLambdaABCD1234',
+        type: 'AWS::Lambda::Function',
+        estimatedMonthlyCost: 4.17,
+        currency: 'USD' as const,
+        basis: '5M req × 200ms × 256MB',
+        unitPrice: 0.0000166667,
+        unit: 'GB-second',
+      };
+      mockCalculateEstimatedCost.mockReturnValue(estimatedResult);
+
+      const handler = makeUsageHandler();
+      const stack = makeStack([makeResource('MyLambdaABCD1234', 'AWS::Lambda::Function')]);
+      const registry = makeRegistry(handler);
+
+      // Both full and stripped IDs present — full ID wins
+      const usageFile = {
+        MyLambdaABCD1234: { requests_per_month: 5000000 },
+        MyLambda: { requests_per_month: 9999999 },
+      };
+      await priceStacks([stack], registry, false, usageFile);
+
+      expect(mockCalculateEstimatedCost).toHaveBeenCalledWith(
+        expect.objectContaining({ logicalId: 'MyLambdaABCD1234' }),
+        { requests_per_month: 5000000 },
+      );
+    });
   });
 
   describe('DynamoDB RCU multiplier', () => {

--- a/tests/unit/utils/string.test.ts
+++ b/tests/unit/utils/string.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { stripCdkHash } from '../../../src/utils/string.js';
+
+describe('stripCdkHash', () => {
+  it('strips 8-char hex suffix with letters in first 4 chars', () => {
+    expect(stripCdkHash('VPCPublicSubnet1NATGatewayE0556630')).toBe('VPCPublicSubnet1NATGateway');
+  });
+
+  it('strips suffix like 99EDD300 (letter in first 4)', () => {
+    expect(stripCdkHash('WebServer99EDD300')).toBe('WebServer');
+  });
+
+  it('keeps ID without any suffix unchanged', () => {
+    expect(stripCdkHash('RedisCluster')).toBe('RedisCluster');
+  });
+
+  it('keeps short IDs (<=8 chars) unchanged', () => {
+    expect(stripCdkHash('Short')).toBe('Short');
+    expect(stripCdkHash('Exactly8')).toBe('Exactly8');
+  });
+
+  it('keeps MyApi49610EDF unchanged — first 4 chars "4961" have no A-F', () => {
+    expect(stripCdkHash('MyApi49610EDF')).toBe('MyApi49610EDF');
+  });
+
+  it('keeps TaskDef54694570 unchanged — suffix "54694570" is digits only, no A-F', () => {
+    expect(stripCdkHash('TaskDef54694570')).toBe('TaskDef54694570');
+  });
+
+  it('strips suffix B269D8BB (B in first 4)', () => {
+    expect(stripCdkHash('DatabaseB269D8BB')).toBe('Database');
+  });
+
+  it('strips suffix CA72566A (C and A in first 4)', () => {
+    expect(stripCdkHash('ProdOnlyBucketCA72566A')).toBe('ProdOnlyBucket');
+  });
+
+  it('keeps ID with lowercase hex suffix unchanged — CDK hashes are uppercase only', () => {
+    expect(stripCdkHash('MyResourceabcdef12')).toBe('MyResourceabcdef12');
+  });
+
+  it('keeps ID where suffix contains non-hex characters', () => {
+    expect(stripCdkHash('MyResourceZZZZZZZZ')).toBe('MyResourceZZZZZZZZ');
+  });
+});


### PR DESCRIPTION
Users who type the stripped display name (e.g. VPCPublicSubnet1NATGateway) into a usage file now get a match, even though the CDK logical ID has an 8-char hash suffix (e.g. VPCPublicSubnet1NATGatewayE0556630). Full ID takes priority when both exist in the usage file.

Move stripCdkHash from src/output/table.ts to src/utils/string.ts so it can be shared between the output layer and the pricing engine.