### PR TITLE
feat: add CloudFront handler (AWS::CloudFront::Distribution)

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -37,6 +37,7 @@ import { apigatewayHandler } from '../registry/handlers/apigateway.js';
 import { secretsManagerHandler } from '../registry/handlers/secretsmanager.js';
 import { eksHandler } from '../registry/handlers/eks.js';
 import { natGatewayHandler } from '../registry/handlers/natgateway.js';
+import { cloudFrontHandler } from '../registry/handlers/cloudfront.js';
 import { EXIT_CODES, StackPriceError } from '../errors/index.js';
 import packageJson from '../../package.json';
 
@@ -91,6 +92,7 @@ function createRegistry(): ResourceHandlerRegistry {
   registry.register(secretsManagerHandler);
   registry.register(eksHandler);
   registry.register(natGatewayHandler);
+  registry.register(cloudFrontHandler);
   return registry;
 }
 

--- a/src/pricing/usage-calculator.ts
+++ b/src/pricing/usage-calculator.ts
@@ -152,6 +152,22 @@ export function calculateEstimatedCost(
       return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
     }
 
+    if (type === 'AWS::CloudFront::Distribution') {
+      const { monthly_requests, monthly_transfer_gb } = usage;
+      if (monthly_requests === undefined || typeof monthly_requests !== 'number') {
+        return null;
+      }
+      if (monthly_transfer_gb === undefined || typeof monthly_transfer_gb !== 'number') {
+        return null;
+      }
+      const CLOUDFRONT_DATA_TRANSFER_RATE = 0.085; // US zone Tier 1 rate. See docs for multi-zone pricing.
+      const requests_cost = monthly_requests * unitPrice;
+      const transfer_cost = monthly_transfer_gb * CLOUDFRONT_DATA_TRANSFER_RATE;
+      const estimatedMonthlyCost = requests_cost + transfer_cost;
+      const basis = `${monthly_requests} requests + ${monthly_transfer_gb}GB transfer (US zone)`;
+      return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+    }
+
     return null;
   } catch {
     return null;

--- a/src/registry/handlers/cloudfront.ts
+++ b/src/registry/handlers/cloudfront.ts
@@ -1,0 +1,27 @@
+import type { ResourceRecord } from '../../template/types.js';
+import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
+import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
+
+export const cloudFrontHandler: ResourceHandler = {
+  resourceType: 'AWS::CloudFront::Distribution',
+  pricingType: 'usage-based',
+
+  extractPricingAttributes(_resource: ResourceRecord): PricingAttributes {
+    return {};
+  },
+
+  buildPricingQuery(_attributes: PricingAttributes, _region: string): PricingQuery {
+    // CloudFront uses geographic zone pricing (US, EU, AP, etc.), not AWS regions.
+    // v0.5.0: always uses US zone pricing as the baseline rate.
+    return {
+      serviceCode: 'AmazonCloudFront',
+      filters: [
+        { field: 'usagetype', value: 'US-Requests-Tier1' },
+      ],
+    };
+  },
+
+  calculateMonthlyCost(_result: PricingApiResult): MonthlyPrice | null {
+    return null;
+  },
+};

--- a/tests/unit/pricing/usage-calculator.test.ts
+++ b/tests/unit/pricing/usage-calculator.test.ts
@@ -375,6 +375,59 @@ describe('calculateEstimatedCost', () => {
     });
   });
 
+  describe('AWS::CloudFront::Distribution', () => {
+    it('calculates combined cost from monthly_requests and monthly_transfer_gb', () => {
+      const resource = makeUsageBasedResource({
+        logicalId: 'MyCDN',
+        type: 'AWS::CloudFront::Distribution',
+        unitPrice: 0.00000075,
+        unit: 'Requests',
+      });
+      const usage = { monthly_requests: 1000000, monthly_transfer_gb: 100 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      // requests_cost = 1000000 * 0.00000075 = 0.75
+      // transfer_cost = 100 * 0.085 = 8.5
+      // total = 9.25
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(9.25, 5);
+      expect(result!.logicalId).toBe('MyCDN');
+      expect(result!.type).toBe('AWS::CloudFront::Distribution');
+      expect(result!.currency).toBe('USD');
+    });
+
+    it('basis string includes requests, GB transfer, and US zone label', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::CloudFront::Distribution',
+        unitPrice: 0.00000075,
+        unit: 'Requests',
+      });
+      const usage = { monthly_requests: 5000000, monthly_transfer_gb: 200 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      expect(result!.basis).toBe('5000000 requests + 200GB transfer (US zone)');
+    });
+
+    it('returns null when monthly_requests is missing', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::CloudFront::Distribution',
+        unitPrice: 0.00000075,
+        unit: 'Requests',
+      });
+      expect(calculateEstimatedCost(resource, { monthly_transfer_gb: 100 })).toBeNull();
+    });
+
+    it('returns null when monthly_transfer_gb is missing', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::CloudFront::Distribution',
+        unitPrice: 0.00000075,
+        unit: 'Requests',
+      });
+      expect(calculateEstimatedCost(resource, { monthly_requests: 1000000 })).toBeNull();
+    });
+  });
+
   describe('unknown resource type', () => {
     it('returns null for an unrecognised type', () => {
       const resource = makeUsageBasedResource({ type: 'AWS::Unknown::Resource' });

--- a/tests/unit/registry/handlers/cloudfront.test.ts
+++ b/tests/unit/registry/handlers/cloudfront.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { cloudFrontHandler } from '../../../../src/registry/handlers/cloudfront.js';
+import type { ResourceRecord } from '../../../../src/template/types.js';
+import type { PricingApiResult } from '../../../../src/pricing/types.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(properties: Record<string, unknown> = {}): ResourceRecord {
+  return { logicalId: 'MyDistribution', type: 'AWS::CloudFront::Distribution', properties };
+}
+
+function makeResult(overrides: Partial<PricingApiResult> = {}): PricingApiResult {
+  return { pricePerUnit: 0.00000075, unit: 'Requests', currency: 'USD', ...overrides };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('cloudFrontHandler', () => {
+  it('has the correct resourceType', () => {
+    expect(cloudFrontHandler.resourceType).toBe('AWS::CloudFront::Distribution');
+  });
+
+  it('pricingType is usage-based', () => {
+    expect(cloudFrontHandler.pricingType).toBe('usage-based');
+  });
+
+  // ─── extractPricingAttributes ───────────────────────────────────────────────
+
+  describe('extractPricingAttributes', () => {
+    it('always returns {}', () => {
+      expect(cloudFrontHandler.extractPricingAttributes(makeResource())).toEqual({});
+    });
+
+    it('returns {} regardless of resource properties', () => {
+      expect(
+        cloudFrontHandler.extractPricingAttributes(
+          makeResource({ DistributionConfig: { Comment: 'test', PriceClass: 'PriceClass_All' } }),
+        ),
+      ).toEqual({});
+    });
+
+    it('never returns null', () => {
+      expect(cloudFrontHandler.extractPricingAttributes(makeResource())).not.toBeNull();
+      expect(
+        cloudFrontHandler.extractPricingAttributes(makeResource({ SomeProperty: 'value' })),
+      ).not.toBeNull();
+    });
+  });
+
+  // ─── buildPricingQuery ──────────────────────────────────────────────────────
+
+  describe('buildPricingQuery', () => {
+    it('uses serviceCode AmazonCloudFront', () => {
+      const attrs = cloudFrontHandler.extractPricingAttributes(makeResource());
+      expect(cloudFrontHandler.buildPricingQuery(attrs, 'us-east-1').serviceCode).toBe(
+        'AmazonCloudFront',
+      );
+    });
+
+    it('sets usagetype filter to US-Requests-Tier1', () => {
+      const attrs = cloudFrontHandler.extractPricingAttributes(makeResource());
+      const query = cloudFrontHandler.buildPricingQuery(attrs, 'us-east-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('US-Requests-Tier1');
+    });
+
+    it('does not include a location filter', () => {
+      const attrs = cloudFrontHandler.extractPricingAttributes(makeResource());
+      const query = cloudFrontHandler.buildPricingQuery(attrs, 'us-east-1');
+      const fieldNames = query.filters.map((f) => f.field);
+      expect(fieldNames).not.toContain('location');
+    });
+
+    it('produces exactly one filter: usagetype', () => {
+      const attrs = cloudFrontHandler.extractPricingAttributes(makeResource());
+      const query = cloudFrontHandler.buildPricingQuery(attrs, 'us-east-1');
+      expect(query.filters).toHaveLength(1);
+      expect(query.filters[0]!.field).toBe('usagetype');
+      expect(query.filters[0]!.value).toBe('US-Requests-Tier1');
+    });
+
+    it('uses the same query regardless of AWS region (zone-based pricing)', () => {
+      const attrs = cloudFrontHandler.extractPricingAttributes(makeResource());
+      const usEast = cloudFrontHandler.buildPricingQuery(attrs, 'us-east-1');
+      const euWest = cloudFrontHandler.buildPricingQuery(attrs, 'eu-west-1');
+      const apSouth = cloudFrontHandler.buildPricingQuery(attrs, 'ap-south-1');
+      expect(usEast).toEqual(euWest);
+      expect(usEast).toEqual(apSouth);
+    });
+  });
+
+  // ─── calculateMonthlyCost ───────────────────────────────────────────────────
+
+  describe('calculateMonthlyCost', () => {
+    it('always returns null', () => {
+      expect(cloudFrontHandler.calculateMonthlyCost(makeResult())).toBeNull();
+    });
+
+    it('returns null regardless of unit', () => {
+      expect(cloudFrontHandler.calculateMonthlyCost(makeResult({ unit: 'Requests' }))).toBeNull();
+      expect(cloudFrontHandler.calculateMonthlyCost(makeResult({ unit: 'GB' }))).toBeNull();
+    });
+
+    it('returns null regardless of pricePerUnit value', () => {
+      expect(cloudFrontHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 }))).toBeNull();
+      expect(
+        cloudFrontHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 9.99 })),
+      ).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Adds usage-based handler for AWS::CloudFront::Distribution using US zone Tier 1 request pricing, and extends calculateEstimatedCost to compute combined request + data transfer cost when monthly_requests and monthly_transfer_gb are provided.