### PR TITLE
feat: include storage cost in RDS handler (hardcoded rates)

### DIFF
--- a/src/output/table.ts
+++ b/src/output/table.ts
@@ -157,5 +157,12 @@ export function formatTable(stacks: PricedStack[], noColor: boolean): string {
 
   lines.push(totalLine);
 
+  const hasRdsResources = stacks.some((s) =>
+    s.pricedResources.some((r) => r.type === 'AWS::RDS::DBInstance'),
+  );
+  if (hasRdsResources) {
+    lines.push('† RDS storage cost uses hardcoded rates (last verified 2026-04-24).\n  Verify current rates at https://aws.amazon.com/rds/pricing/');
+  }
+
   return lines.join('\n');
 }

--- a/src/pricing/engine.ts
+++ b/src/pricing/engine.ts
@@ -190,7 +190,7 @@ export async function priceStacks(
           condOut.unitPrice = result.pricePerUnit;
           condOut.unit = result.unit;
         } else {
-          const monthlyPrice = handler.calculateMonthlyCost(result);
+          const monthlyPrice = handler.calculateMonthlyCost(result, attrs);
           if (monthlyPrice !== null) {
             condOut.monthlyCost = applyMultipliers(resource.type, monthlyPrice.amount, attrs);
           }
@@ -218,7 +218,7 @@ export async function priceStacks(
           usageBasedResources.push(usageBasedResource);
         }
       } else {
-        const monthlyPrice = handler.calculateMonthlyCost(result);
+        const monthlyPrice = handler.calculateMonthlyCost(result, attrs);
         if (monthlyPrice !== null) {
           pricedResources.push({
             logicalId: resource.logicalId,

--- a/src/registry/handler.ts
+++ b/src/registry/handler.ts
@@ -100,8 +100,10 @@ export interface ResourceHandler {
   /**
    * Compute the monthly cost from a single Pricing API result.
    * Returns null if the result has an unexpected unit or is otherwise unusable.
+   * attrs is optional and passed through from the engine for handlers that need
+   * resource-level properties (e.g. RDS storage configuration) in cost calculation.
    */
-  calculateMonthlyCost(result: PricingApiResult): MonthlyPrice | null;
+  calculateMonthlyCost(result: PricingApiResult, attrs?: PricingAttributes): MonthlyPrice | null;
 
   /**
    * Build the usage-based component query for mixed handlers.

--- a/src/registry/handlers/rds.ts
+++ b/src/registry/handlers/rds.ts
@@ -7,6 +7,8 @@ interface RdsAttributes extends PricingAttributes {
   instanceType: string;
   databaseEngine: string;
   multiAZ: boolean;
+  allocatedStorage: number;
+  storageType: string;
 }
 
 /**
@@ -23,6 +25,43 @@ const CF_ENGINE_TO_PRICING: Record<string, string> = {
   'sqlserver-web': 'SQL Server',
   'sqlserver-se': 'SQL Server',
   'sqlserver-ee': 'SQL Server',
+};
+
+/**
+ * HARDCODED: RDS storage rates per GB-month, verified against
+ * the AWS Pricing API on 2026-04-24.
+ *
+ * Verification command (run per storage type):
+ *   aws pricing get-products --service-code AmazonRDS \
+ *     --region us-east-1 \
+ *     --filters \
+ *       "Type=TERM_MATCH,Field=productFamily,Value=Database Storage" \
+ *       "Type=TERM_MATCH,Field=location,Value=US East (N. Virginia)" \
+ *       "Type=TERM_MATCH,Field=volumeType,Value=General Purpose" \
+ *       "Type=TERM_MATCH,Field=deploymentOption,Value=Single-AZ"
+ *
+ * If AWS changes storage pricing, update both maps below,
+ * update the verified date in this comment, and update the
+ * hardcoded pricing table in CLAUDE.md.
+ * Reference: https://aws.amazon.com/rds/pricing/
+ *
+ * Note: Multi-AZ rates are approximately 2× Single-AZ rates.
+ * io1 and io2 IOPS charges are NOT included — only storage GB cost.
+ */
+const STORAGE_RATES_SINGLE_AZ: Record<string, number> = {
+  'gp2':      0.115,
+  'gp3':      0.115,
+  'io1':      0.125,
+  'io2':      0.125,
+  'standard': 0.100,
+};
+
+const STORAGE_RATES_MULTI_AZ: Record<string, number> = {
+  'gp2':      0.230,
+  'gp3':      0.230,
+  'io1':      0.250,
+  'io2':      0.250,
+  'standard': 0.200,
 };
 
 export const rdsHandler: ResourceHandler = {
@@ -44,7 +83,17 @@ export const rdsHandler: ResourceHandler = {
     const databaseEngine = CF_ENGINE_TO_PRICING[engine];
     if (databaseEngine === undefined) return null;
 
-    return { instanceType: instanceClass, databaseEngine, multiAZ } satisfies RdsAttributes;
+    const allocatedStorageRaw = properties['AllocatedStorage'];
+    const allocatedStorage = typeof allocatedStorageRaw === 'number'
+      ? Math.floor(allocatedStorageRaw)
+      : 20;
+
+    const storageTypeRaw = properties['StorageType'];
+    const storageType = typeof storageTypeRaw === 'string'
+      ? storageTypeRaw.toLowerCase()
+      : 'gp2';
+
+    return { instanceType: instanceClass, databaseEngine, multiAZ, allocatedStorage, storageType } satisfies RdsAttributes;
   },
 
   buildPricingQuery(attributes: PricingAttributes, region: string): PricingQuery {
@@ -63,11 +112,22 @@ export const rdsHandler: ResourceHandler = {
     };
   },
 
-  calculateMonthlyCost(result: PricingApiResult): MonthlyPrice | null {
+  calculateMonthlyCost(result: PricingApiResult, attrs?: PricingAttributes): MonthlyPrice | null {
     if (result.unit !== 'Hrs') return null;
+
+    const instanceCost = result.pricePerUnit * 730;
+
+    const allocatedStorage = (attrs?.['allocatedStorage'] as number | undefined) ?? 20;
+    const storageType = (attrs?.['storageType'] as string | undefined) ?? 'gp2';
+    const multiAZ = (attrs?.['multiAZ'] as boolean | undefined) ?? false;
+
+    const rateMap = multiAZ ? STORAGE_RATES_MULTI_AZ : STORAGE_RATES_SINGLE_AZ;
+    const storageRate = rateMap[storageType] ?? rateMap['gp2']!;
+    const storageCost = allocatedStorage * storageRate;
+
     return {
-      amount: result.pricePerUnit * 730,
-      currency: result.currency,
+      amount: instanceCost + storageCost,
+      currency: 'USD',
       unit: result.unit,
     };
   },

--- a/tests/unit/registry/handlers/rds.test.ts
+++ b/tests/unit/registry/handlers/rds.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { rdsHandler } from '../../../../src/registry/handlers/rds.js';
 import type { ResourceRecord } from '../../../../src/template/types.js';
 import type { PricingApiResult } from '../../../../src/pricing/types.js';
+import type { PricingAttributes } from '../../../../src/registry/handler.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -166,6 +167,41 @@ describe('rdsHandler', () => {
       );
       expect(attrs!['multiAZ']).toBe(true);
     });
+
+    it('allocatedStorage extracted correctly', () => {
+      const attrs = rdsHandler.extractPricingAttributes(
+        makeResource({ DBInstanceClass: 'db.t3.medium', Engine: 'mysql', AllocatedStorage: 50 }),
+      );
+      expect(attrs!['allocatedStorage']).toBe(50);
+    });
+
+    it('allocatedStorage defaults to 20 when absent', () => {
+      const attrs = rdsHandler.extractPricingAttributes(
+        makeResource({ DBInstanceClass: 'db.t3.medium', Engine: 'mysql' }),
+      );
+      expect(attrs!['allocatedStorage']).toBe(20);
+    });
+
+    it('storageType extracted and lowercased', () => {
+      const attrs = rdsHandler.extractPricingAttributes(
+        makeResource({ DBInstanceClass: 'db.t3.medium', Engine: 'mysql', StorageType: 'GP2' }),
+      );
+      expect(attrs!['storageType']).toBe('gp2');
+    });
+
+    it('storageType defaults to gp2 when absent', () => {
+      const attrs = rdsHandler.extractPricingAttributes(
+        makeResource({ DBInstanceClass: 'db.t3.medium', Engine: 'mysql' }),
+      );
+      expect(attrs!['storageType']).toBe('gp2');
+    });
+
+    it('multiAZ extracted correctly', () => {
+      const attrs = rdsHandler.extractPricingAttributes(
+        makeResource({ DBInstanceClass: 'db.t3.medium', Engine: 'mysql', MultiAZ: true }),
+      );
+      expect(attrs!['multiAZ']).toBe(true);
+    });
   });
 
   // ─── buildPricingQuery ──────────────────────────────────────────────────────
@@ -246,10 +282,11 @@ describe('rdsHandler', () => {
   // ─── calculateMonthlyCost ───────────────────────────────────────────────────
 
   describe('calculateMonthlyCost', () => {
-    it('returns pricePerUnit × 730 for unit Hrs', () => {
+    it('returns instance cost + default storage cost for unit Hrs', () => {
       const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0.24 }));
       expect(price).not.toBeNull();
-      expect(price!.amount).toBeCloseTo(0.24 * 730);
+      // defaults: 20GB gp2 single-AZ → 20 * 0.115 = 2.30
+      expect(price!.amount).toBeCloseTo(0.24 * 730 + 20 * 0.115);
     });
 
     it('preserves currency and unit', () => {
@@ -267,9 +304,71 @@ describe('rdsHandler', () => {
     });
 
     it('calculates correctly for a zero pricePerUnit', () => {
-      expect(rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 }))!.amount).toBe(
-        0,
+      // only storage cost remains: 20GB gp2 = 2.30
+      expect(rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 }))!.amount).toBeCloseTo(
+        20 * 0.115,
       );
+    });
+
+    // ─── Storage cost scenarios ─────────────────────────────────────────────
+
+    describe('storage cost component', () => {
+      const pricePerUnit = 0.24;
+      const instanceCost = pricePerUnit * 730;
+
+      function makeAttrs(storageProps: Record<string, unknown> = {}): PricingAttributes {
+        return rdsHandler.extractPricingAttributes(
+          makeResource({ DBInstanceClass: 'db.t3.medium', Engine: 'mysql', ...storageProps }),
+        )!;
+      }
+
+      it('gp2 Single-AZ: instance + gp2 storage cost', () => {
+        const attrs = makeAttrs({ AllocatedStorage: 100, StorageType: 'gp2', MultiAZ: false });
+        const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit }), attrs);
+        expect(price!.amount).toBeCloseTo(instanceCost + 100 * 0.115);
+      });
+
+      it('gp3 Single-AZ: instance + gp3 storage cost (same rate as gp2)', () => {
+        const attrs = makeAttrs({ AllocatedStorage: 100, StorageType: 'gp3', MultiAZ: false });
+        const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit }), attrs);
+        expect(price!.amount).toBeCloseTo(instanceCost + 100 * 0.115);
+      });
+
+      it('io1 Single-AZ: instance + io1 storage cost', () => {
+        const attrs = makeAttrs({ AllocatedStorage: 100, StorageType: 'io1', MultiAZ: false });
+        const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit }), attrs);
+        expect(price!.amount).toBeCloseTo(instanceCost + 100 * 0.125);
+      });
+
+      it('standard Single-AZ: instance + magnetic storage cost', () => {
+        const attrs = makeAttrs({ AllocatedStorage: 100, StorageType: 'standard', MultiAZ: false });
+        const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit }), attrs);
+        expect(price!.amount).toBeCloseTo(instanceCost + 100 * 0.100);
+      });
+
+      it('Multi-AZ: instance + 2× storage rate', () => {
+        const attrs = makeAttrs({ AllocatedStorage: 100, StorageType: 'gp2', MultiAZ: true });
+        const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit }), attrs);
+        expect(price!.amount).toBeCloseTo(instanceCost + 100 * 0.230);
+      });
+
+      it('AllocatedStorage absent: defaults to 20GB', () => {
+        const attrs = makeAttrs({ StorageType: 'gp2', MultiAZ: false });
+        const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit }), attrs);
+        expect(price!.amount).toBeCloseTo(instanceCost + 20 * 0.115);
+      });
+
+      it('StorageType absent: defaults to gp2 rate', () => {
+        const attrs = makeAttrs({ AllocatedStorage: 100, MultiAZ: false });
+        const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit }), attrs);
+        expect(price!.amount).toBeCloseTo(instanceCost + 100 * 0.115);
+      });
+
+      it('Unknown StorageType: falls back to gp2 rate', () => {
+        const attrs = makeAttrs({ AllocatedStorage: 100, StorageType: 'io3', MultiAZ: false });
+        const price = rdsHandler.calculateMonthlyCost(makeResult({ pricePerUnit }), attrs);
+        expect(price!.amount).toBeCloseTo(instanceCost + 100 * 0.115);
+      });
     });
   });
 });


### PR DESCRIPTION
RDS storage (GB-month) is now included in the monthly total alongside instance hours. Rates are hardcoded for gp2/gp3/io1/io2/standard, both Single-AZ and Multi-AZ, verified against AWS Pricing API on 2026-04-24. calculateMonthlyCost now accepts optional PricingAttributes so RDS can read AllocatedStorage, StorageType, and MultiAZ for the storage component. A disclaimer is printed when RDS resources appear in the output.