### PR TITLE
feat: add Kinesis Streams handler (AWS::Kinesis::Stream)

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -38,6 +38,7 @@ import { secretsManagerHandler } from '../registry/handlers/secretsmanager.js';
 import { eksHandler } from '../registry/handlers/eks.js';
 import { natGatewayHandler } from '../registry/handlers/natgateway.js';
 import { cloudFrontHandler } from '../registry/handlers/cloudfront.js';
+import { kinesisHandler } from '../registry/handlers/kinesis.js';
 import { EXIT_CODES, StackPriceError } from '../errors/index.js';
 import packageJson from '../../package.json';
 
@@ -93,6 +94,7 @@ function createRegistry(): ResourceHandlerRegistry {
   registry.register(eksHandler);
   registry.register(natGatewayHandler);
   registry.register(cloudFrontHandler);
+  registry.register(kinesisHandler);
   return registry;
 }
 

--- a/src/registry/handlers/kinesis.ts
+++ b/src/registry/handlers/kinesis.ts
@@ -1,0 +1,119 @@
+import type { ResourceRecord } from '../../template/types.js';
+import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
+import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
+import { REGION_TO_LOCATION } from '../handler.js';
+
+// Maps AWS region codes to the usagetype prefix used in Kinesis Streams pricing.
+// us-east-1 uses NO prefix — undefined means omit the prefix entirely.
+const REGION_TO_KINESIS_PREFIX: Record<string, string | undefined> = {
+  'us-east-1':      undefined,
+  'us-east-2':      'USE2',
+  'us-west-1':      'USW1',
+  'us-west-2':      'USW2',
+  'eu-west-1':      'EU',
+  'eu-west-2':      'EUW2',
+  'eu-west-3':      'EUW3',
+  'eu-central-1':   'EUC1',
+  'eu-central-2':   'EUC2',
+  'eu-north-1':     'EUN1',
+  'eu-south-1':     'EUS1',
+  'eu-south-2':     'EUS2',
+  'ap-southeast-1': 'APS1',
+  'ap-southeast-2': 'APS2',
+  'ap-southeast-3': 'APS3',
+  'ap-southeast-4': 'APS4',
+  'ap-southeast-5': 'APS5',
+  'ap-southeast-6': 'APS6',
+  'ap-southeast-7': 'APS7',
+  'ap-southeast-8': 'APS8',
+  'ap-southeast-9': 'APS9',
+  'ap-northeast-1': 'APN1',
+  'ap-northeast-2': 'APN2',
+  'ap-northeast-3': 'APN3',
+  'ap-south-1':     'APS1',
+  'ap-south-2':     'APS2',
+  'ap-east-1':      'APE1',
+  'ap-east-2':      'APE2',
+  'ca-central-1':   'CAN1',
+  'ca-west-1':      'CAN2',
+  'sa-east-1':      'SAE1',
+  'af-south-1':     'AFS1',
+  'me-south-1':     'MES1',
+  'me-central-1':   'MEC1',
+  'il-central-1':   'ILC1',
+  'mx-central-1':   'MXC1',
+  'us-gov-east-1':  'UGE1',
+  'us-gov-west-1':  'UGW1',
+};
+
+export const kinesisHandler: ResourceHandler = {
+  resourceType: 'AWS::Kinesis::Stream',
+  pricingType: 'fixed',
+
+  extractPricingAttributes(resource: ResourceRecord): PricingAttributes {
+    const props = resource.properties;
+    const streamModeDetails = props['StreamModeDetails'];
+    let streamMode: string = 'PROVISIONED';
+    if (
+      streamModeDetails !== null &&
+      typeof streamModeDetails === 'object' &&
+      !Array.isArray(streamModeDetails)
+    ) {
+      const details = streamModeDetails as Record<string, unknown>;
+      if (typeof details['StreamMode'] === 'string') {
+        streamMode = details['StreamMode'];
+      }
+    }
+
+    const rawShardCount = props['ShardCount'];
+    const shardCount = typeof rawShardCount === 'number' ? rawShardCount : 1;
+
+    return { streamMode, shardCount };
+  },
+
+  buildPricingQuery(attributes: PricingAttributes, region: string): PricingQuery {
+    const location = REGION_TO_LOCATION[region] ?? region;
+    const isOnDemand = attributes['streamMode'] === 'ON_DEMAND';
+
+    const filters: PricingQuery['filters'] = [
+      { field: 'productFamily', value: 'Kinesis Streams' },
+      { field: 'location', value: location },
+    ];
+
+    if (region in REGION_TO_KINESIS_PREFIX) {
+      const prefix = REGION_TO_KINESIS_PREFIX[region];
+      if (isOnDemand) {
+        const usagetype = prefix ? `${prefix}-OnDemand-StreamHour` : 'OnDemand-StreamHour';
+        filters.push({ field: 'usagetype', value: usagetype });
+      } else {
+        const usagetype = prefix ? `${prefix}-Storage-ShardHour` : 'Storage-ShardHour';
+        filters.push({ field: 'usagetype', value: usagetype });
+      }
+    }
+    // unknown region: omit usagetype filter (graceful fallback)
+
+    return { serviceCode: 'AmazonKinesis', filters };
+  },
+
+  calculateMonthlyCost(result: PricingApiResult, attrs?: PricingAttributes): MonthlyPrice | null {
+    const streamMode = attrs?.['streamMode'];
+    const isOnDemand = streamMode === 'ON_DEMAND';
+
+    if (isOnDemand) {
+      if (result.unit !== 'StreamHr') return null;
+      return {
+        amount: result.pricePerUnit * 730,
+        currency: result.currency,
+        unit: result.unit,
+      };
+    }
+
+    if (result.unit !== 'ShardHour') return null;
+    const shardCount = typeof attrs?.['shardCount'] === 'number' ? (attrs['shardCount'] as number) : 1;
+    return {
+      amount: result.pricePerUnit * 730 * shardCount,
+      currency: result.currency,
+      unit: result.unit,
+    };
+  },
+};

--- a/tests/unit/registry/handlers/kinesis.test.ts
+++ b/tests/unit/registry/handlers/kinesis.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect } from 'vitest';
+import { kinesisHandler } from '../../../../src/registry/handlers/kinesis.js';
+import type { PricingApiResult } from '../../../../src/pricing/types.js';
+import type { ResourceRecord } from '../../../../src/template/types.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(overrides: Partial<Record<string, unknown>> = {}): ResourceRecord {
+  return {
+    logicalId: 'MyKinesisStream',
+    type: 'AWS::Kinesis::Stream',
+    properties: { ...overrides },
+  };
+}
+
+function makeResult(unit: string, pricePerUnit = 0.015): PricingApiResult {
+  return { pricePerUnit, unit, currency: 'USD' };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('kinesisHandler', () => {
+  it('has pricingType: fixed', () => {
+    expect(kinesisHandler.pricingType).toBe('fixed');
+  });
+
+  it('has resourceType: AWS::Kinesis::Stream', () => {
+    expect(kinesisHandler.resourceType).toBe('AWS::Kinesis::Stream');
+  });
+
+  describe('extractPricingAttributes', () => {
+    it('detects PROVISIONED mode from StreamModeDetails', () => {
+      const resource = makeResource({
+        StreamModeDetails: { StreamMode: 'PROVISIONED' },
+        ShardCount: 2,
+      });
+      const attrs = kinesisHandler.extractPricingAttributes(resource);
+      expect(attrs?.['streamMode']).toBe('PROVISIONED');
+    });
+
+    it('detects ON_DEMAND mode from StreamModeDetails', () => {
+      const resource = makeResource({
+        StreamModeDetails: { StreamMode: 'ON_DEMAND' },
+      });
+      const attrs = kinesisHandler.extractPricingAttributes(resource);
+      expect(attrs?.['streamMode']).toBe('ON_DEMAND');
+    });
+
+    it('defaults to PROVISIONED when StreamModeDetails absent', () => {
+      const resource = makeResource({ ShardCount: 3 });
+      const attrs = kinesisHandler.extractPricingAttributes(resource);
+      expect(attrs?.['streamMode']).toBe('PROVISIONED');
+    });
+
+    it('extracts ShardCount correctly', () => {
+      const resource = makeResource({ ShardCount: 5 });
+      const attrs = kinesisHandler.extractPricingAttributes(resource);
+      expect(attrs?.['shardCount']).toBe(5);
+    });
+
+    it('defaults ShardCount to 1 when absent', () => {
+      const resource = makeResource({});
+      const attrs = kinesisHandler.extractPricingAttributes(resource);
+      expect(attrs?.['shardCount']).toBe(1);
+    });
+
+    it('defaults to PROVISIONED when StreamModeDetails is a non-object value', () => {
+      const resource = makeResource({ StreamModeDetails: 'invalid' });
+      const attrs = kinesisHandler.extractPricingAttributes(resource);
+      expect(attrs?.['streamMode']).toBe('PROVISIONED');
+    });
+
+    it('defaults to PROVISIONED when StreamModeDetails is an array', () => {
+      const resource = makeResource({ StreamModeDetails: ['PROVISIONED'] });
+      const attrs = kinesisHandler.extractPricingAttributes(resource);
+      expect(attrs?.['streamMode']).toBe('PROVISIONED');
+    });
+
+    it('defaults to PROVISIONED when StreamModeDetails object has non-string StreamMode', () => {
+      const resource = makeResource({ StreamModeDetails: { StreamMode: 42 } });
+      const attrs = kinesisHandler.extractPricingAttributes(resource);
+      expect(attrs?.['streamMode']).toBe('PROVISIONED');
+    });
+
+    it('never returns null', () => {
+      expect(kinesisHandler.extractPricingAttributes(makeResource())).not.toBeNull();
+      expect(kinesisHandler.extractPricingAttributes(makeResource({ ShardCount: 3 }))).not.toBeNull();
+    });
+  });
+
+  describe('buildPricingQuery (PROVISIONED)', () => {
+    const provisionedAttrs = { streamMode: 'PROVISIONED', shardCount: 1 };
+
+    it('us-east-1: usagetype = "Storage-ShardHour" (no prefix)', () => {
+      const query = kinesisHandler.buildPricingQuery(provisionedAttrs, 'us-east-1');
+      const usageFilter = query.filters.find((f) => f.field === 'usagetype');
+      expect(usageFilter?.value).toBe('Storage-ShardHour');
+    });
+
+    it('eu-west-1: usagetype = "EU-Storage-ShardHour"', () => {
+      const query = kinesisHandler.buildPricingQuery(provisionedAttrs, 'eu-west-1');
+      const usageFilter = query.filters.find((f) => f.field === 'usagetype');
+      expect(usageFilter?.value).toBe('EU-Storage-ShardHour');
+    });
+
+    it('us-west-2: usagetype = "USW2-Storage-ShardHour"', () => {
+      const query = kinesisHandler.buildPricingQuery(provisionedAttrs, 'us-west-2');
+      const usageFilter = query.filters.find((f) => f.field === 'usagetype');
+      expect(usageFilter?.value).toBe('USW2-Storage-ShardHour');
+    });
+
+    it('unknown region: usagetype filter omitted', () => {
+      const query = kinesisHandler.buildPricingQuery(provisionedAttrs, 'xx-unknown-1');
+      const usageFilter = query.filters.find((f) => f.field === 'usagetype');
+      expect(usageFilter).toBeUndefined();
+    });
+
+    it('always includes location filter', () => {
+      const query = kinesisHandler.buildPricingQuery(provisionedAttrs, 'us-east-1');
+      const loc = query.filters.find((f) => f.field === 'location');
+      expect(loc?.value).toBe('US East (N. Virginia)');
+    });
+
+    it('always includes productFamily filter', () => {
+      const query = kinesisHandler.buildPricingQuery(provisionedAttrs, 'us-east-1');
+      const pf = query.filters.find((f) => f.field === 'productFamily');
+      expect(pf?.value).toBe('Kinesis Streams');
+    });
+
+    it('uses serviceCode AmazonKinesis', () => {
+      const query = kinesisHandler.buildPricingQuery(provisionedAttrs, 'us-east-1');
+      expect(query.serviceCode).toBe('AmazonKinesis');
+    });
+  });
+
+  describe('buildPricingQuery (ON_DEMAND)', () => {
+    const onDemandAttrs = { streamMode: 'ON_DEMAND', shardCount: 1 };
+
+    it('us-east-1: usagetype = "OnDemand-StreamHour" (no prefix)', () => {
+      const query = kinesisHandler.buildPricingQuery(onDemandAttrs, 'us-east-1');
+      const usageFilter = query.filters.find((f) => f.field === 'usagetype');
+      expect(usageFilter?.value).toBe('OnDemand-StreamHour');
+    });
+
+    it('eu-west-1: usagetype = "EU-OnDemand-StreamHour"', () => {
+      const query = kinesisHandler.buildPricingQuery(onDemandAttrs, 'eu-west-1');
+      const usageFilter = query.filters.find((f) => f.field === 'usagetype');
+      expect(usageFilter?.value).toBe('EU-OnDemand-StreamHour');
+    });
+
+    it('ap-northeast-1: usagetype = "APN1-OnDemand-StreamHour"', () => {
+      const query = kinesisHandler.buildPricingQuery(onDemandAttrs, 'ap-northeast-1');
+      const usageFilter = query.filters.find((f) => f.field === 'usagetype');
+      expect(usageFilter?.value).toBe('APN1-OnDemand-StreamHour');
+    });
+
+    it('unknown region: usagetype filter omitted', () => {
+      const query = kinesisHandler.buildPricingQuery(onDemandAttrs, 'xx-unknown-1');
+      const usageFilter = query.filters.find((f) => f.field === 'usagetype');
+      expect(usageFilter).toBeUndefined();
+    });
+
+    it('always includes location filter', () => {
+      const query = kinesisHandler.buildPricingQuery(onDemandAttrs, 'eu-west-1');
+      const loc = query.filters.find((f) => f.field === 'location');
+      expect(loc?.value).toBe('EU (Ireland)');
+    });
+
+    it('uses serviceCode AmazonKinesis', () => {
+      const query = kinesisHandler.buildPricingQuery(onDemandAttrs, 'us-east-1');
+      expect(query.serviceCode).toBe('AmazonKinesis');
+    });
+  });
+
+  describe('calculateMonthlyCost (PROVISIONED)', () => {
+    it('1 shard: pricePerUnit × 730 × 1', () => {
+      const attrs = { streamMode: 'PROVISIONED', shardCount: 1 };
+      const result = kinesisHandler.calculateMonthlyCost(makeResult('ShardHour', 0.015), attrs);
+      expect(result).not.toBeNull();
+      expect(result!.amount).toBeCloseTo(0.015 * 730 * 1, 5);
+      expect(result!.currency).toBe('USD');
+      expect(result!.unit).toBe('ShardHour');
+    });
+
+    it('3 shards: pricePerUnit × 730 × 3', () => {
+      const attrs = { streamMode: 'PROVISIONED', shardCount: 3 };
+      const result = kinesisHandler.calculateMonthlyCost(makeResult('ShardHour', 0.015), attrs);
+      expect(result).not.toBeNull();
+      expect(result!.amount).toBeCloseTo(0.015 * 730 * 3, 5);
+    });
+
+    it('wrong unit: returns null', () => {
+      const attrs = { streamMode: 'PROVISIONED', shardCount: 1 };
+      expect(kinesisHandler.calculateMonthlyCost(makeResult('StreamHr', 0.015), attrs)).toBeNull();
+    });
+
+    it('defaults shardCount to 1 when attrs absent', () => {
+      const result = kinesisHandler.calculateMonthlyCost(makeResult('ShardHour', 0.015));
+      expect(result).not.toBeNull();
+      expect(result!.amount).toBeCloseTo(0.015 * 730, 5);
+    });
+  });
+
+  describe('calculateMonthlyCost (ON_DEMAND)', () => {
+    it('pricePerUnit × 730', () => {
+      const attrs = { streamMode: 'ON_DEMAND', shardCount: 1 };
+      const result = kinesisHandler.calculateMonthlyCost(makeResult('StreamHr', 0.04), attrs);
+      expect(result).not.toBeNull();
+      expect(result!.amount).toBeCloseTo(0.04 * 730, 5);
+      expect(result!.currency).toBe('USD');
+      expect(result!.unit).toBe('StreamHr');
+    });
+
+    it('wrong unit: returns null', () => {
+      const attrs = { streamMode: 'ON_DEMAND', shardCount: 1 };
+      expect(kinesisHandler.calculateMonthlyCost(makeResult('ShardHour', 0.04), attrs)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Supports both PROVISIONED (per-shard hourly) and ON_DEMAND capacity modes. Handles the us-east-1 no-prefix anomaly for usagetype filters.