### PR TITLE
feat: add CloudWatch Logs handler (AWS::Logs::LogGroup)

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -39,6 +39,7 @@ import { eksHandler } from '../registry/handlers/eks.js';
 import { natGatewayHandler } from '../registry/handlers/natgateway.js';
 import { cloudFrontHandler } from '../registry/handlers/cloudfront.js';
 import { kinesisHandler } from '../registry/handlers/kinesis.js';
+import { cloudWatchLogsHandler } from '../registry/handlers/cloudwatchlogs.js';
 import { EXIT_CODES, StackPriceError } from '../errors/index.js';
 import packageJson from '../../package.json';
 
@@ -95,6 +96,7 @@ function createRegistry(): ResourceHandlerRegistry {
   registry.register(natGatewayHandler);
   registry.register(cloudFrontHandler);
   registry.register(kinesisHandler);
+  registry.register(cloudWatchLogsHandler);
   return registry;
 }
 

--- a/src/generate/usage-file-generator.ts
+++ b/src/generate/usage-file-generator.ts
@@ -7,13 +7,14 @@ import { readAssembly } from '../assembly/reader.js';
 // ─── Type map (short name → CloudFormation type) ──────────────────────────────
 
 export const TYPE_MAP: Record<string, string> = {
-  Lambda:     'AWS::Lambda::Function',
-  S3:         'AWS::S3::Bucket',
-  SQS:        'AWS::SQS::Queue',
-  SNS:        'AWS::SNS::Topic',
-  ApiGateway: 'AWS::ApiGateway::RestApi',
-  NatGateway: 'AWS::EC2::NatGateway',
-  CloudFront: 'AWS::CloudFront::Distribution',
+  Lambda:       'AWS::Lambda::Function',
+  S3:           'AWS::S3::Bucket',
+  SQS:          'AWS::SQS::Queue',
+  SNS:          'AWS::SNS::Topic',
+  ApiGateway:   'AWS::ApiGateway::RestApi',
+  NatGateway:   'AWS::EC2::NatGateway',
+  CloudFront:   'AWS::CloudFront::Distribution',
+  LogsLogGroup: 'AWS::Logs::LogGroup',
 };
 
 // Handlers registered as pricingType: 'usage-based' or 'mixed' in the registry
@@ -23,9 +24,10 @@ const REGISTERED_USAGE_BASED_TYPES = new Set([
   'AWS::SQS::Queue',
   'AWS::SNS::Topic',
   'AWS::ApiGateway::RestApi',
+  'AWS::Logs::LogGroup',
 ]);
 
-// Not yet registered but planned for v0.5.0 — include anyway for future-proofing
+// Not yet registered but planned — include anyway for future-proofing
 const UPCOMING_USAGE_BASED_TYPES = new Set([
   'AWS::EC2::NatGateway',
   'AWS::CloudFront::Distribution',
@@ -45,6 +47,7 @@ const TYPE_ORDER = [
   'AWS::ApiGateway::RestApi',
   'AWS::EC2::NatGateway',
   'AWS::CloudFront::Distribution',
+  'AWS::Logs::LogGroup',
 ];
 
 // ─── Exported interfaces ──────────────────────────────────────────────────────
@@ -266,6 +269,18 @@ function cloudfrontYamlEntry(resource: UsageResource): string[] {
   return lines;
 }
 
+function cloudwatchlogsYamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { logicalId } = resource;
+
+  lines.push('# Storage rate ($0.03/GB-month) is hardcoded');
+  lines.push(`${logicalId}:`);
+  lines.push(commentLine('  ingestion_gb: 0', 'TODO: GB of log data ingested per month'));
+  lines.push(commentLine('  storage_gb: 0', 'TODO: GB of logs stored (average)'));
+
+  return lines;
+}
+
 function generateYamlEntry(resource: UsageResource): string[] {
   switch (resource.type) {
     case 'AWS::Lambda::Function':         return lambdaYamlEntry(resource);
@@ -275,6 +290,7 @@ function generateYamlEntry(resource: UsageResource): string[] {
     case 'AWS::ApiGateway::RestApi':      return apigatewayYamlEntry(resource);
     case 'AWS::EC2::NatGateway':          return natgatewayYamlEntry(resource);
     case 'AWS::CloudFront::Distribution': return cloudfrontYamlEntry(resource);
+    case 'AWS::Logs::LogGroup':           return cloudwatchlogsYamlEntry(resource);
     default:                              return [];
   }
 }
@@ -325,6 +341,12 @@ function buildJsonEntry(resource: UsageResource): Record<string, unknown> {
       entry['_note'] = 'Prices shown for US edge locations. Actual costs vary by geographic zone.';
       entry['monthly_requests'] = 0;
       entry['monthly_transfer_gb'] = 0;
+      break;
+    }
+    case 'AWS::Logs::LogGroup': {
+      entry['_note'] = 'Storage rate ($0.03/GB-month) is hardcoded';
+      entry['ingestion_gb'] = 0;
+      entry['storage_gb'] = 0;
       break;
     }
     default:

--- a/src/pricing/types.ts
+++ b/src/pricing/types.ts
@@ -69,6 +69,7 @@ export interface ResourceUsage {
   data_transfer_gb?: number;
   monthly_requests?: number;
   monthly_transfer_gb?: number;
+  ingestion_gb?: number;
 }
 
 export type UsageFile = Record<string, ResourceUsage>;

--- a/src/pricing/usage-calculator.ts
+++ b/src/pricing/usage-calculator.ts
@@ -78,6 +78,9 @@ export function parseUsageFile(filePath: string): UsageFile {
     if (typeof entry['monthly_transfer_gb'] === 'number') {
       usage.monthly_transfer_gb = entry['monthly_transfer_gb'];
     }
+    if (typeof entry['ingestion_gb'] === 'number') {
+      usage.ingestion_gb = entry['ingestion_gb'];
+    }
     result[key] = usage;
   }
 
@@ -165,6 +168,30 @@ export function calculateEstimatedCost(
       const transfer_cost = monthly_transfer_gb * CLOUDFRONT_DATA_TRANSFER_RATE;
       const estimatedMonthlyCost = requests_cost + transfer_cost;
       const basis = `${monthly_requests} requests + ${monthly_transfer_gb}GB transfer (US zone)`;
+      return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+    }
+
+    if (type === 'AWS::Logs::LogGroup') {
+      const ingestion = usage.ingestion_gb ?? 0;
+      const storage = usage.storage_gb ?? 0;
+      if (ingestion === 0 && storage === 0) {
+        return null;
+      }
+      // Storage rate hardcoded — verify at https://aws.amazon.com/cloudwatch/pricing/
+      const CLOUDWATCH_STORAGE_RATE = 0.03;
+      const ingestion_cost = ingestion * unitPrice;
+      const storage_cost = storage * CLOUDWATCH_STORAGE_RATE;
+      const estimatedMonthlyCost = ingestion_cost + storage_cost;
+
+      let basis: string;
+      if (ingestion > 0 && storage > 0) {
+        basis = `${ingestion}GB ingested + ${storage}GB stored`;
+      } else if (ingestion > 0) {
+        basis = `${ingestion}GB ingested`;
+      } else {
+        basis = `${storage}GB stored`;
+      }
+
       return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
     }
 

--- a/src/registry/handlers/cloudwatchlogs.ts
+++ b/src/registry/handlers/cloudwatchlogs.ts
@@ -1,0 +1,79 @@
+import type { ResourceRecord } from '../../template/types.js';
+import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
+import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
+
+interface CloudWatchLogsAttributes extends PricingAttributes {
+  retentionDays?: number;
+}
+
+// Maps AWS region codes to the usagetype prefix used in CloudWatch Logs pricing.
+// Format: "{prefix}-DataProcessing-Bytes" (ingestion) / "{prefix}-TimedStorage-ByteHrs" (storage)
+const REGION_TO_CWL_PREFIX: Record<string, string> = {
+  'us-east-1':      'USE1',
+  'us-east-2':      'USE2',
+  'us-west-1':      'USW1',
+  'us-west-2':      'USW2',
+  'eu-west-1':      'EU',
+  'eu-west-2':      'EUW2',
+  'eu-west-3':      'EUW3',
+  'eu-central-1':   'EUC1',
+  'eu-central-2':   'EUC2',
+  'eu-north-1':     'EUN1',
+  'eu-south-1':     'EUS1',
+  'eu-south-2':     'EUS2',
+  'ap-southeast-1': 'APS1',
+  'ap-southeast-2': 'APS2',
+  'ap-southeast-3': 'APS3',
+  'ap-southeast-4': 'APS4',
+  'ap-southeast-5': 'APS5',
+  'ap-southeast-6': 'APS6',
+  'ap-southeast-7': 'APS7',
+  'ap-southeast-8': 'APS8',
+  'ap-southeast-9': 'APS9',
+  'ap-northeast-1': 'APN1',
+  'ap-northeast-2': 'APN2',
+  'ap-northeast-3': 'APN3',
+  'ap-south-1':     'APS1',
+  'ap-south-2':     'APS2',
+  'ap-east-1':      'APE1',
+  'ap-east-2':      'APE2',
+  'ca-central-1':   'CAN1',
+  'ca-west-1':      'CAN2',
+  'sa-east-1':      'SAE1',
+  'af-south-1':     'AFS1',
+  'me-south-1':     'MES1',
+  'me-central-1':   'MEC1',
+  'il-central-1':   'ILC1',
+  'mx-central-1':   'MXC1',
+  'us-gov-east-1':  'UGE1',
+  'us-gov-west-1':  'UGW1',
+};
+
+export const cloudWatchLogsHandler: ResourceHandler = {
+  resourceType: 'AWS::Logs::LogGroup',
+  pricingType: 'usage-based',
+
+  extractPricingAttributes(resource: ResourceRecord): PricingAttributes {
+    const attrs: CloudWatchLogsAttributes = {};
+    const retention = resource.properties['RetentionInDays'];
+    if (typeof retention === 'number') {
+      attrs.retentionDays = retention;
+    }
+    return attrs;
+  },
+
+  buildPricingQuery(_attributes: PricingAttributes, region: string): PricingQuery {
+    const prefix = REGION_TO_CWL_PREFIX[region];
+    const filters: PricingQuery['filters'] = [];
+
+    if (prefix !== undefined) {
+      filters.push({ field: 'usagetype', value: `${prefix}-DataProcessing-Bytes` });
+    }
+
+    return { serviceCode: 'AmazonCloudWatch', filters };
+  },
+
+  calculateMonthlyCost(_result: PricingApiResult): MonthlyPrice | null {
+    return null;
+  },
+};

--- a/tests/unit/pricing/usage-calculator.test.ts
+++ b/tests/unit/pricing/usage-calculator.test.ts
@@ -428,6 +428,81 @@ describe('calculateEstimatedCost', () => {
     });
   });
 
+  describe('AWS::Logs::LogGroup', () => {
+    it('calculates combined cost from ingestion_gb and storage_gb', () => {
+      const resource = makeUsageBasedResource({
+        logicalId: 'AppLogGroup',
+        type: 'AWS::Logs::LogGroup',
+        unitPrice: 0.50,
+        unit: 'GB',
+      });
+      const usage = { ingestion_gb: 10, storage_gb: 50 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      // ingestion_cost = 10 * 0.50 = 5.00
+      // storage_cost   = 50 * 0.03 = 1.50
+      // total = 6.50
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(6.50, 5);
+      expect(result!.logicalId).toBe('AppLogGroup');
+      expect(result!.type).toBe('AWS::Logs::LogGroup');
+      expect(result!.currency).toBe('USD');
+    });
+
+    it('calculates ingestion-only cost when storage_gb is absent', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::Logs::LogGroup',
+        unitPrice: 0.50,
+        unit: 'GB',
+      });
+      const usage = { ingestion_gb: 10 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(5.00, 5);
+      expect(result!.basis).toBe('10GB ingested');
+    });
+
+    it('calculates storage-only cost when ingestion_gb is absent', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::Logs::LogGroup',
+        unitPrice: 0.50,
+        unit: 'GB',
+      });
+      const usage = { storage_gb: 100 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      // ingestion_cost = 0 * 0.50 = 0.00
+      // storage_cost   = 100 * 0.03 = 3.00
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(3.00, 5);
+      expect(result!.basis).toBe('100GB stored');
+    });
+
+    it('returns null when both ingestion_gb and storage_gb are absent', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::Logs::LogGroup' });
+      expect(calculateEstimatedCost(resource, {})).toBeNull();
+    });
+
+    it('returns null when both ingestion_gb and storage_gb are zero', () => {
+      const resource = makeUsageBasedResource({ type: 'AWS::Logs::LogGroup' });
+      expect(calculateEstimatedCost(resource, { ingestion_gb: 0, storage_gb: 0 })).toBeNull();
+    });
+
+    it('basis includes both components when both are non-zero', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::Logs::LogGroup',
+        unitPrice: 0.50,
+        unit: 'GB',
+      });
+      const usage = { ingestion_gb: 10, storage_gb: 50 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      expect(result!.basis).toBe('10GB ingested + 50GB stored');
+    });
+  });
+
   describe('unknown resource type', () => {
     it('returns null for an unrecognised type', () => {
       const resource = makeUsageBasedResource({ type: 'AWS::Unknown::Resource' });

--- a/tests/unit/registry/handlers/cloudwatchlogs.test.ts
+++ b/tests/unit/registry/handlers/cloudwatchlogs.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import { cloudWatchLogsHandler } from '../../../../src/registry/handlers/cloudwatchlogs.js';
+import type { ResourceRecord } from '../../../../src/template/types.js';
+import type { PricingApiResult } from '../../../../src/pricing/types.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(properties: Record<string, unknown> = {}): ResourceRecord {
+  return { logicalId: 'MyLogGroup', type: 'AWS::Logs::LogGroup', properties };
+}
+
+function makeResult(overrides: Partial<PricingApiResult> = {}): PricingApiResult {
+  return { pricePerUnit: 0.50, unit: 'GB', currency: 'USD', ...overrides };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('cloudWatchLogsHandler', () => {
+  it('has the correct resourceType', () => {
+    expect(cloudWatchLogsHandler.resourceType).toBe('AWS::Logs::LogGroup');
+  });
+
+  it('pricingType is usage-based', () => {
+    expect(cloudWatchLogsHandler.pricingType).toBe('usage-based');
+  });
+
+  // ─── extractPricingAttributes ───────────────────────────────────────────────
+
+  describe('extractPricingAttributes', () => {
+    it('extracts RetentionInDays when present', () => {
+      const attrs = cloudWatchLogsHandler.extractPricingAttributes(
+        makeResource({ RetentionInDays: 30 }),
+      );
+      expect(attrs).toMatchObject({ retentionDays: 30 });
+    });
+
+    it('returns {} when properties are absent', () => {
+      expect(cloudWatchLogsHandler.extractPricingAttributes(makeResource())).toEqual({});
+    });
+
+    it('ignores RetentionInDays when it is not a number', () => {
+      const attrs = cloudWatchLogsHandler.extractPricingAttributes(
+        makeResource({ RetentionInDays: 'never' }),
+      );
+      expect(attrs).toEqual({});
+    });
+
+    it('never returns null', () => {
+      expect(cloudWatchLogsHandler.extractPricingAttributes(makeResource())).not.toBeNull();
+      expect(
+        cloudWatchLogsHandler.extractPricingAttributes(makeResource({ RetentionInDays: 7 })),
+      ).not.toBeNull();
+    });
+  });
+
+  // ─── buildPricingQuery ──────────────────────────────────────────────────────
+
+  describe('buildPricingQuery', () => {
+    it('uses serviceCode AmazonCloudWatch', () => {
+      const attrs = cloudWatchLogsHandler.extractPricingAttributes(makeResource());
+      expect(cloudWatchLogsHandler.buildPricingQuery(attrs, 'us-east-1').serviceCode).toBe(
+        'AmazonCloudWatch',
+      );
+    });
+
+    it('sets usagetype to "USE1-DataProcessing-Bytes" for us-east-1', () => {
+      const attrs = cloudWatchLogsHandler.extractPricingAttributes(makeResource());
+      const query = cloudWatchLogsHandler.buildPricingQuery(attrs, 'us-east-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('USE1-DataProcessing-Bytes');
+    });
+
+    it('sets usagetype to "EU-DataProcessing-Bytes" for eu-west-1', () => {
+      const attrs = cloudWatchLogsHandler.extractPricingAttributes(makeResource());
+      const query = cloudWatchLogsHandler.buildPricingQuery(attrs, 'eu-west-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('EU-DataProcessing-Bytes');
+    });
+
+    it('omits usagetype filter for an unknown region', () => {
+      const attrs = cloudWatchLogsHandler.extractPricingAttributes(makeResource());
+      const query = cloudWatchLogsHandler.buildPricingQuery(attrs, 'xx-unknown-1');
+      expect(query.filters).toHaveLength(0);
+    });
+
+    it('includes exactly one filter for a known region', () => {
+      const attrs = cloudWatchLogsHandler.extractPricingAttributes(makeResource());
+      const query = cloudWatchLogsHandler.buildPricingQuery(attrs, 'us-west-2');
+      expect(query.filters).toHaveLength(1);
+      expect(query.filters[0]!.field).toBe('usagetype');
+      expect(query.filters[0]!.value).toBe('USW2-DataProcessing-Bytes');
+    });
+  });
+
+  // ─── calculateMonthlyCost ───────────────────────────────────────────────────
+
+  describe('calculateMonthlyCost', () => {
+    it('always returns null', () => {
+      expect(cloudWatchLogsHandler.calculateMonthlyCost(makeResult())).toBeNull();
+    });
+
+    it('returns null regardless of unit', () => {
+      expect(cloudWatchLogsHandler.calculateMonthlyCost(makeResult({ unit: 'GB' }))).toBeNull();
+      expect(cloudWatchLogsHandler.calculateMonthlyCost(makeResult({ unit: 'GB-Mo' }))).toBeNull();
+    });
+
+    it('returns null regardless of pricePerUnit', () => {
+      expect(cloudWatchLogsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 }))).toBeNull();
+      expect(cloudWatchLogsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0.50 }))).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Adds usage-based pricing support for AWS::Logs::LogGroup with ingestion ($0.50/GB) and storage ($0.03/GB-month) cost components. Registers handler, extends usage-calculator and usage-file-generator.