### PR TITLE
feat: add Step Functions handler (AWS::StepFunctions::StateMachine)

### DIFF
--- a/src/cli/parser.ts
+++ b/src/cli/parser.ts
@@ -41,6 +41,7 @@ import { cloudFrontHandler } from '../registry/handlers/cloudfront.js';
 import { kinesisHandler } from '../registry/handlers/kinesis.js';
 import { cloudWatchLogsHandler } from '../registry/handlers/cloudwatchlogs.js';
 import { firehoseHandler } from '../registry/handlers/firehose.js';
+import { stepFunctionsHandler } from '../registry/handlers/stepfunctions.js';
 import { EXIT_CODES, StackPriceError } from '../errors/index.js';
 import packageJson from '../../package.json';
 
@@ -99,6 +100,7 @@ function createRegistry(): ResourceHandlerRegistry {
   registry.register(kinesisHandler);
   registry.register(cloudWatchLogsHandler);
   registry.register(firehoseHandler);
+  registry.register(stepFunctionsHandler);
   return registry;
 }
 

--- a/src/generate/usage-file-generator.ts
+++ b/src/generate/usage-file-generator.ts
@@ -16,6 +16,7 @@ export const TYPE_MAP: Record<string, string> = {
   CloudFront:   'AWS::CloudFront::Distribution',
   LogsLogGroup:           'AWS::Logs::LogGroup',
   FirehoseDeliveryStream: 'AWS::KinesisFirehose::DeliveryStream',
+  StepFunctions:          'AWS::StepFunctions::StateMachine',
 };
 
 // Handlers registered as pricingType: 'usage-based' or 'mixed' in the registry
@@ -27,6 +28,7 @@ const REGISTERED_USAGE_BASED_TYPES = new Set([
   'AWS::ApiGateway::RestApi',
   'AWS::Logs::LogGroup',
   'AWS::KinesisFirehose::DeliveryStream',
+  'AWS::StepFunctions::StateMachine',
 ]);
 
 // Not yet registered but planned — include anyway for future-proofing
@@ -51,6 +53,7 @@ const TYPE_ORDER = [
   'AWS::CloudFront::Distribution',
   'AWS::Logs::LogGroup',
   'AWS::KinesisFirehose::DeliveryStream',
+  'AWS::StepFunctions::StateMachine',
 ];
 
 // ─── Exported interfaces ──────────────────────────────────────────────────────
@@ -294,6 +297,27 @@ function firehoseYamlEntry(resource: UsageResource): string[] {
   return lines;
 }
 
+function stepFunctionsYamlEntry(resource: UsageResource): string[] {
+  const lines: string[] = [];
+  const { properties, logicalId } = resource;
+
+  const isExpress = properties['StateMachineType'] === 'EXPRESS';
+
+  if (isExpress) {
+    lines.push(`# AWS::StepFunctions::StateMachine (Express)`);
+    lines.push(`${logicalId}:`);
+    lines.push(commentLine('  monthly_requests: 0', 'TODO: workflow executions per month'));
+    lines.push(commentLine('  avg_duration_ms: 0', 'TODO: average execution duration in ms'));
+    lines.push(commentLine('  memory_mb: 64', 'pre-filled (Express default)'));
+  } else {
+    lines.push(`# AWS::StepFunctions::StateMachine (Standard)`);
+    lines.push(`${logicalId}:`);
+    lines.push(commentLine('  monthly_transitions: 0', 'TODO: state transitions per month'));
+  }
+
+  return lines;
+}
+
 function generateYamlEntry(resource: UsageResource): string[] {
   switch (resource.type) {
     case 'AWS::Lambda::Function':                    return lambdaYamlEntry(resource);
@@ -305,6 +329,7 @@ function generateYamlEntry(resource: UsageResource): string[] {
     case 'AWS::CloudFront::Distribution':            return cloudfrontYamlEntry(resource);
     case 'AWS::Logs::LogGroup':                      return cloudwatchlogsYamlEntry(resource);
     case 'AWS::KinesisFirehose::DeliveryStream':     return firehoseYamlEntry(resource);
+    case 'AWS::StepFunctions::StateMachine':         return stepFunctionsYamlEntry(resource);
     default:                                          return [];
   }
 }
@@ -365,6 +390,19 @@ function buildJsonEntry(resource: UsageResource): Record<string, unknown> {
     }
     case 'AWS::KinesisFirehose::DeliveryStream': {
       entry['ingestion_gb'] = 0;
+      break;
+    }
+    case 'AWS::StepFunctions::StateMachine': {
+      const isExpress = p['StateMachineType'] === 'EXPRESS';
+      if (isExpress) {
+        entry['_workflow_type'] = 'Express';
+        entry['monthly_requests'] = 0;
+        entry['avg_duration_ms'] = 0;
+        entry['memory_mb'] = 64;
+      } else {
+        entry['_workflow_type'] = 'Standard';
+        entry['monthly_transitions'] = 0;
+      }
       break;
     }
     default:

--- a/src/pricing/types.ts
+++ b/src/pricing/types.ts
@@ -70,6 +70,7 @@ export interface ResourceUsage {
   monthly_requests?: number;
   monthly_transfer_gb?: number;
   ingestion_gb?: number;
+  monthly_transitions?: number;
 }
 
 export type UsageFile = Record<string, ResourceUsage>;

--- a/src/pricing/usage-calculator.ts
+++ b/src/pricing/usage-calculator.ts
@@ -81,6 +81,9 @@ export function parseUsageFile(filePath: string): UsageFile {
     if (typeof entry['ingestion_gb'] === 'number') {
       usage.ingestion_gb = entry['ingestion_gb'];
     }
+    if (typeof entry['monthly_transitions'] === 'number') {
+      usage.monthly_transitions = entry['monthly_transitions'];
+    }
     result[key] = usage;
   }
 
@@ -203,6 +206,31 @@ export function calculateEstimatedCost(
       }
 
       return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+    }
+
+    if (type === 'AWS::StepFunctions::StateMachine') {
+      const { monthly_transitions, monthly_requests, avg_duration_ms } = usage;
+
+      if (monthly_transitions !== undefined) {
+        // Standard workflow — charged per state transition
+        const estimatedMonthlyCost = monthly_transitions * unitPrice;
+        const basis = `${monthly_transitions} state transitions`;
+        return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+      }
+
+      if (monthly_requests !== undefined && avg_duration_ms !== undefined) {
+        // Express workflow — charged per request + duration × memory
+        const memory_mb = usage.memory_mb ?? 64;
+        const gb_seconds = (memory_mb / 1024) * (avg_duration_ms / 1000) * monthly_requests;
+        const request_cost = monthly_requests * unitPrice;
+        const STEPFUNCTIONS_EXPRESS_DURATION_RATE = 0.0000167;
+        const duration_cost = gb_seconds * STEPFUNCTIONS_EXPRESS_DURATION_RATE;
+        const estimatedMonthlyCost = request_cost + duration_cost;
+        const basis = `${monthly_requests} requests × ${avg_duration_ms}ms × ${memory_mb}MB`;
+        return { logicalId, type, estimatedMonthlyCost, currency, basis, unitPrice, unit };
+      }
+
+      return null;
     }
 
     return null;

--- a/src/registry/handlers/stepfunctions.ts
+++ b/src/registry/handlers/stepfunctions.ts
@@ -1,0 +1,83 @@
+import type { ResourceRecord } from '../../template/types.js';
+import type { PricingQuery, PricingApiResult } from '../../pricing/types.js';
+import type { ResourceHandler, PricingAttributes, MonthlyPrice } from '../handler.js';
+
+interface StepFunctionsAttributes extends PricingAttributes {
+  stateMachineType: 'STANDARD' | 'EXPRESS';
+}
+
+// Maps AWS region codes to the usagetype prefix used in Step Functions pricing.
+// Format (Standard): "{prefix}-StateTransition"
+// Format (Express):  "{prefix}-StepFunctions-Request" / "{prefix}-StepFunctions-GB-Second"
+const REGION_TO_SF_PREFIX: Record<string, string> = {
+  'us-east-1':      'USE1',
+  'us-east-2':      'USE2',
+  'us-west-1':      'USW1',
+  'us-west-2':      'USW2',
+  'eu-west-1':      'EU',
+  'eu-west-2':      'EUW2',
+  'eu-west-3':      'EUW3',
+  'eu-central-1':   'EUC1',
+  'eu-central-2':   'EUC2',
+  'eu-north-1':     'EUN1',
+  'eu-south-1':     'EUS1',
+  'eu-south-2':     'EUS2',
+  'ap-southeast-1': 'APS1',
+  'ap-southeast-2': 'APS2',
+  'ap-southeast-3': 'APS3',
+  'ap-southeast-4': 'APS4',
+  'ap-southeast-5': 'APS5',
+  'ap-southeast-6': 'APS6',
+  'ap-southeast-7': 'APS7',
+  'ap-southeast-8': 'APS8',
+  'ap-southeast-9': 'APS9',
+  'ap-northeast-1': 'APN1',
+  'ap-northeast-2': 'APN2',
+  'ap-northeast-3': 'APN3',
+  'ap-south-1':     'APS1',
+  'ap-south-2':     'APS2',
+  'ap-east-1':      'APE1',
+  'ap-east-2':      'APE2',
+  'ca-central-1':   'CAN1',
+  'ca-west-1':      'CAN2',
+  'sa-east-1':      'SAE1',
+  'af-south-1':     'AFS1',
+  'me-south-1':     'MES1',
+  'me-central-1':   'MEC1',
+  'il-central-1':   'ILC1',
+  'mx-central-1':   'MXC1',
+  'us-gov-east-1':  'UGE1',
+  'us-gov-west-1':  'UGW1',
+};
+
+export const stepFunctionsHandler: ResourceHandler = {
+  resourceType: 'AWS::StepFunctions::StateMachine',
+  pricingType: 'usage-based',
+
+  extractPricingAttributes(resource: ResourceRecord): StepFunctionsAttributes {
+    const type = resource.properties['StateMachineType'];
+    const stateMachineType: 'STANDARD' | 'EXPRESS' =
+      type === 'EXPRESS' ? 'EXPRESS' : 'STANDARD';
+    return { stateMachineType };
+  },
+
+  buildPricingQuery(attributes: PricingAttributes, region: string): PricingQuery {
+    const attrs = attributes as StepFunctionsAttributes;
+    const prefix = REGION_TO_SF_PREFIX[region];
+    const filters: PricingQuery['filters'] = [];
+
+    if (prefix !== undefined) {
+      if (attrs.stateMachineType === 'EXPRESS') {
+        filters.push({ field: 'usagetype', value: `${prefix}-StepFunctions-Request` });
+      } else {
+        filters.push({ field: 'usagetype', value: `${prefix}-StateTransition` });
+      }
+    }
+
+    return { serviceCode: 'AmazonStates', filters };
+  },
+
+  calculateMonthlyCost(_result: PricingApiResult): MonthlyPrice | null {
+    return null;
+  },
+};

--- a/tests/unit/pricing/usage-calculator.test.ts
+++ b/tests/unit/pricing/usage-calculator.test.ts
@@ -204,6 +204,15 @@ describe('parseUsageFile', () => {
     expect(() => parseUsageFile('/some/usage.txt')).toThrow('--usage-file must be');
     expect(mockReadFileSync).not.toHaveBeenCalled();
   });
+
+  it('parses monthly_transitions for Step Functions Standard workflows', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('yaml content');
+    mockYamlLoad.mockReturnValue({ MyStateMachine: { monthly_transitions: 1000000 } });
+
+    const result = parseUsageFile('/some/usage.yml');
+    expect(result).toEqual({ MyStateMachine: { monthly_transitions: 1000000 } });
+  });
 });
 
 describe('calculateEstimatedCost', () => {
@@ -539,6 +548,107 @@ describe('calculateEstimatedCost', () => {
       });
       const result = calculateEstimatedCost(resource, { ingestion_gb: 500 });
       expect(result!.basis).toBe('500GB ingested');
+    });
+  });
+
+  describe('AWS::StepFunctions::StateMachine (Standard)', () => {
+    it('calculates cost from monthly_transitions', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::StepFunctions::StateMachine',
+        unitPrice: 0.000025,
+        unit: 'StateTransitions',
+      });
+      const result = calculateEstimatedCost(resource, { monthly_transitions: 1000000 });
+
+      expect(result).not.toBeNull();
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(25.0);
+      expect(result!.basis).toBe('1000000 state transitions');
+      expect(result!.logicalId).toBe(resource.logicalId);
+      expect(result!.type).toBe('AWS::StepFunctions::StateMachine');
+    });
+
+    it('returns null when monthly_transitions is missing', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::StepFunctions::StateMachine',
+        unitPrice: 0.000025,
+        unit: 'StateTransitions',
+      });
+      expect(calculateEstimatedCost(resource, {})).toBeNull();
+    });
+
+    it('basis string uses correct format', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::StepFunctions::StateMachine',
+        unitPrice: 0.000025,
+        unit: 'StateTransitions',
+      });
+      const result = calculateEstimatedCost(resource, { monthly_transitions: 500 });
+      expect(result!.basis).toBe('500 state transitions');
+    });
+  });
+
+  describe('AWS::StepFunctions::StateMachine (Express)', () => {
+    it('calculates combined request + duration cost', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::StepFunctions::StateMachine',
+        unitPrice: 0.000001,
+        unit: 'Requests',
+      });
+      const usage = { monthly_requests: 1000000, avg_duration_ms: 100, memory_mb: 64 };
+      const result = calculateEstimatedCost(resource, usage);
+
+      expect(result).not.toBeNull();
+      // request_cost = 1_000_000 * 0.000001 = 1.0
+      // gb_seconds = (64/1024) * (100/1000) * 1_000_000 = 6250
+      // duration_cost = 6250 * 0.0000167 = 0.10437...
+      // total ≈ 1.10437
+      expect(result!.estimatedMonthlyCost).toBeCloseTo(1.10437, 3);
+      expect(result!.basis).toBe('1000000 requests × 100ms × 64MB');
+      expect(result!.type).toBe('AWS::StepFunctions::StateMachine');
+    });
+
+    it('defaults memory_mb to 64 when absent', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::StepFunctions::StateMachine',
+        unitPrice: 0.000001,
+        unit: 'Requests',
+      });
+      const result = calculateEstimatedCost(resource, { monthly_requests: 100, avg_duration_ms: 200 });
+
+      expect(result).not.toBeNull();
+      expect(result!.basis).toContain('64MB');
+    });
+
+    it('returns null when monthly_requests is missing', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::StepFunctions::StateMachine',
+        unitPrice: 0.000001,
+        unit: 'Requests',
+      });
+      expect(calculateEstimatedCost(resource, { avg_duration_ms: 100 })).toBeNull();
+    });
+
+    it('returns null when avg_duration_ms is missing', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::StepFunctions::StateMachine',
+        unitPrice: 0.000001,
+        unit: 'Requests',
+      });
+      expect(calculateEstimatedCost(resource, { monthly_requests: 1000000 })).toBeNull();
+    });
+
+    it('basis string uses correct format', () => {
+      const resource = makeUsageBasedResource({
+        type: 'AWS::StepFunctions::StateMachine',
+        unitPrice: 0.000001,
+        unit: 'Requests',
+      });
+      const result = calculateEstimatedCost(resource, {
+        monthly_requests: 5000000,
+        avg_duration_ms: 500,
+        memory_mb: 128,
+      });
+      expect(result!.basis).toBe('5000000 requests × 500ms × 128MB');
     });
   });
 

--- a/tests/unit/registry/handlers/stepfunctions.test.ts
+++ b/tests/unit/registry/handlers/stepfunctions.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { stepFunctionsHandler } from '../../../../src/registry/handlers/stepfunctions.js';
+import type { ResourceRecord } from '../../../../src/template/types.js';
+import type { PricingApiResult } from '../../../../src/pricing/types.js';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeResource(properties: Record<string, unknown> = {}): ResourceRecord {
+  return { logicalId: 'MyStateMachine', type: 'AWS::StepFunctions::StateMachine', properties };
+}
+
+function makeResult(overrides: Partial<PricingApiResult> = {}): PricingApiResult {
+  return { pricePerUnit: 0.000025, unit: 'StateTransitions', currency: 'USD', ...overrides };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('stepFunctionsHandler', () => {
+  it('has the correct resourceType', () => {
+    expect(stepFunctionsHandler.resourceType).toBe('AWS::StepFunctions::StateMachine');
+  });
+
+  it('pricingType is usage-based', () => {
+    expect(stepFunctionsHandler.pricingType).toBe('usage-based');
+  });
+
+  // ─── extractPricingAttributes ───────────────────────────────────────────────
+
+  describe('extractPricingAttributes', () => {
+    it('detects STANDARD when StateMachineType is "STANDARD"', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(
+        makeResource({ StateMachineType: 'STANDARD' }),
+      );
+      expect(attrs).toMatchObject({ stateMachineType: 'STANDARD' });
+    });
+
+    it('detects EXPRESS when StateMachineType is "EXPRESS"', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(
+        makeResource({ StateMachineType: 'EXPRESS' }),
+      );
+      expect(attrs).toMatchObject({ stateMachineType: 'EXPRESS' });
+    });
+
+    it('defaults to STANDARD when StateMachineType is absent', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(makeResource());
+      expect(attrs).toMatchObject({ stateMachineType: 'STANDARD' });
+    });
+
+    it('defaults to STANDARD for unrecognised StateMachineType values', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(
+        makeResource({ StateMachineType: 'UNKNOWN' }),
+      );
+      expect(attrs).toMatchObject({ stateMachineType: 'STANDARD' });
+    });
+
+    it('never returns null', () => {
+      expect(stepFunctionsHandler.extractPricingAttributes(makeResource())).not.toBeNull();
+      expect(
+        stepFunctionsHandler.extractPricingAttributes(makeResource({ StateMachineType: 'EXPRESS' })),
+      ).not.toBeNull();
+    });
+  });
+
+  // ─── buildPricingQuery (STANDARD) ──────────────────────────────────────────
+
+  describe('buildPricingQuery (STANDARD)', () => {
+    it('uses serviceCode AmazonStates', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(makeResource());
+      expect(stepFunctionsHandler.buildPricingQuery(attrs, 'us-east-1').serviceCode).toBe(
+        'AmazonStates',
+      );
+    });
+
+    it('sets usagetype to "USE1-StateTransition" for us-east-1', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(makeResource());
+      const query = stepFunctionsHandler.buildPricingQuery(attrs, 'us-east-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('USE1-StateTransition');
+    });
+
+    it('sets usagetype to "EU-StateTransition" for eu-west-1', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(makeResource());
+      const query = stepFunctionsHandler.buildPricingQuery(attrs, 'eu-west-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('EU-StateTransition');
+    });
+
+    it('omits usagetype filter for an unknown region', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(makeResource());
+      const query = stepFunctionsHandler.buildPricingQuery(attrs, 'xx-unknown-1');
+      expect(query.filters).toHaveLength(0);
+    });
+
+    it('includes exactly one filter for a known region', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(makeResource());
+      const query = stepFunctionsHandler.buildPricingQuery(attrs, 'us-west-2');
+      expect(query.filters).toHaveLength(1);
+      expect(query.filters[0]!.field).toBe('usagetype');
+      expect(query.filters[0]!.value).toBe('USW2-StateTransition');
+    });
+  });
+
+  // ─── buildPricingQuery (EXPRESS) ──────────────────────────────────────────
+
+  describe('buildPricingQuery (EXPRESS)', () => {
+    it('uses serviceCode AmazonStates', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(
+        makeResource({ StateMachineType: 'EXPRESS' }),
+      );
+      expect(stepFunctionsHandler.buildPricingQuery(attrs, 'us-east-1').serviceCode).toBe(
+        'AmazonStates',
+      );
+    });
+
+    it('sets usagetype to "USE1-StepFunctions-Request" for us-east-1', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(
+        makeResource({ StateMachineType: 'EXPRESS' }),
+      );
+      const query = stepFunctionsHandler.buildPricingQuery(attrs, 'us-east-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('USE1-StepFunctions-Request');
+    });
+
+    it('sets usagetype to "EU-StepFunctions-Request" for eu-west-1', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(
+        makeResource({ StateMachineType: 'EXPRESS' }),
+      );
+      const query = stepFunctionsHandler.buildPricingQuery(attrs, 'eu-west-1');
+      const usagetype = query.filters.find((f) => f.field === 'usagetype')?.value;
+      expect(usagetype).toBe('EU-StepFunctions-Request');
+    });
+
+    it('omits usagetype filter for an unknown region', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(
+        makeResource({ StateMachineType: 'EXPRESS' }),
+      );
+      const query = stepFunctionsHandler.buildPricingQuery(attrs, 'xx-unknown-1');
+      expect(query.filters).toHaveLength(0);
+    });
+
+    it('includes exactly one filter for a known region', () => {
+      const attrs = stepFunctionsHandler.extractPricingAttributes(
+        makeResource({ StateMachineType: 'EXPRESS' }),
+      );
+      const query = stepFunctionsHandler.buildPricingQuery(attrs, 'ap-east-1');
+      expect(query.filters).toHaveLength(1);
+      expect(query.filters[0]!.field).toBe('usagetype');
+      expect(query.filters[0]!.value).toBe('APE1-StepFunctions-Request');
+    });
+  });
+
+  // ─── calculateMonthlyCost ───────────────────────────────────────────────────
+
+  describe('calculateMonthlyCost', () => {
+    it('always returns null', () => {
+      expect(stepFunctionsHandler.calculateMonthlyCost(makeResult())).toBeNull();
+    });
+
+    it('returns null regardless of unit', () => {
+      expect(
+        stepFunctionsHandler.calculateMonthlyCost(makeResult({ unit: 'StateTransitions' })),
+      ).toBeNull();
+      expect(
+        stepFunctionsHandler.calculateMonthlyCost(makeResult({ unit: 'Requests' })),
+      ).toBeNull();
+    });
+
+    it('returns null regardless of pricePerUnit', () => {
+      expect(
+        stepFunctionsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0 })),
+      ).toBeNull();
+      expect(
+        stepFunctionsHandler.calculateMonthlyCost(makeResult({ pricePerUnit: 0.000025 })),
+      ).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Supports Standard (per-transition) and Express (per-request + GB-second duration) pricing via AmazonStates Pricing API. Adds monthly_transitions to ResourceUsage, calculateEstimatedCost cases for both workflow types, YAML/JSON usage-file generation, and 100% handler test coverage.