### PR TITLE
chore: v0.7.1 release prep — CHANGELOG and version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 All notable changes to stackprice are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com).
 
+## [0.7.1] - 2026-05-15
+
+### Changed
+- Dependency updates: @aws-sdk/client-pricing, @aws-sdk/credential-providers,
+  @typescript-eslint/eslint-plugin, @typescript-eslint/parser, eslint,
+  vitest — all patch/minor version bumps via Dependabot.
+- chalk v5.x ignored in Dependabot — stackprice uses CommonJS
+  (chalk v5 is ESM-only and incompatible).
+
+### Added
+- CONTRIBUTING.md — development setup, handler authoring guide,
+  code standards, testing requirements, commit and branch conventions.
+- Pull request template — checklist for contributors.
+- Security policy (SECURITY.md).
+- Issue templates — bug report and feature request.
+
 ## [0.7.0] - 2026-04-24
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stackprice",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "AWS CDK infrastructure pricing estimation CLI — know what it costs before you deploy",
   "keywords": [
     "aws",


### PR DESCRIPTION
## What does this PR do?

Release prep and documentation update for v0.7.1

## Type of change

- [ ] New resource handler (`AWS::Service::Resource`)
- [ ] Bug fix
- [ ] New feature / command
- [x] Documentation update
- [ ] Dependency update
- [ ] Refactor / cleanup

## Checklist

- [x] `npm test` passes with zero failures
- [x] `npm run build` exits clean
- [x] `npm run lint` exits clean
- [ ] New handler files have 100% coverage
- [ ] No `console.log()` in `src/`
- [ ] No real AWS API calls in tests

## For new handlers only

- [ ] Pricing API values verified with live `aws pricing get-products` queries
- [ ] Hardcoded pricing values include verification comment with date and AWS pricing URL
- [ ] Handler registered in `src/cli/parser.ts`
- [ ] Usage-based handlers added to `usage-calculator.ts` and `usage-file-generator.ts`
- [ ] Usage-based handlers added to `usage-file-generator.ts` TYPE_MAP

## Related issues

<!-- Closes #123 -->
