### PR TITLE
chore : update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       day: monday
       time: "09:00"
       timezone: Asia/Kolkata
+    ignore:
+      - dependency-name: "chalk"
+        versions: ["5.x", ">=5.0.0"]
+      - dependency-name: "commander"
+        versions: ["15.x", ">=15.0.0"]
     open-pull-requests-limit: 5
     labels:
       - dependencies


### PR DESCRIPTION
adding ignore conditions

## What does this PR do?

<!-- Brief description of the change -->

Adds Dependabot ignore rules for chalk (v5.x) and commander (v15.x).
Both major versions are ESM-only and incompatible with stackprice's
CommonJS build (module: "commonjs" in tsconfig). Prevents Dependabot
from repeatedly opening PRs for these incompatible major versions.

## Type of change

- [ ] New resource handler (`AWS::Service::Resource`)
- [ ] Bug fix
- [ ] New feature / command
- [ ] Documentation update
- [x] Dependency update
- [ ] Refactor / cleanup

## Checklist

- [x] `npm test` passes with zero failures
- [x] `npm run build` exits clean
- [x] `npm run lint` exits clean
- [ ] New handler files have 100% coverage
- [x] No `console.log()` in `src/`
- [x] No real AWS API calls in tests

## For new handlers only

- [ ] Pricing API values verified with live `aws pricing get-products` queries
- [ ] Hardcoded pricing values include verification comment with date and AWS pricing URL
- [ ] Handler registered in `src/cli/parser.ts`
- [ ] Usage-based handlers added to `usage-calculator.ts` and `usage-file-generator.ts`
- [ ] Usage-based handlers added to `usage-file-generator.ts` TYPE_MAP

## Related issues

Relates to #59 (chalk v5 — closed) and #114 (commander v15 — to be closed)

<!-- Closes #123 -->
